### PR TITLE
Class check

### DIFF
--- a/avae/data.py
+++ b/avae/data.py
@@ -176,6 +176,14 @@ class ProteinDataset(Dataset):
 
         self.amatrix = amatrix
 
+        class_check = np.in1d(class_list, self.amatrix.columns)
+        if not np.all(class_check):
+            raise RuntimeError(
+                "Not all classes in the training set are present in the affinity matrix"
+                "Missing classes: {}".format(
+                    np.asarray(class_list)[~class_check]
+                )
+            )
         if not transform:
             self.transform = transforms.Compose(
                 [

--- a/avae/data.py
+++ b/avae/data.py
@@ -170,9 +170,7 @@ class ProteinDataset(Dataset):
                     c.strip() for c in class_list if len(c.strip()) != 0
                 ]
 
-            self.paths = sorted(
-                [p for p in self.paths for c in class_list if c in p]
-            )
+            self.paths = [p for p in self.paths for c in class_list if c in p]
 
         self.paths = self.paths[:lim]
 


### PR DESCRIPTION
Fixes #29 (branch name was supposed to be `29-class-check` but I didn't see the typo until it was too late :-( )

- Check that classes in the selected training set are in the affinity matrix
- Removes sorting of paths which undoes the shuffling of data in the previous step

