### PR TITLE
Check that affinity and classes files exists

### DIFF
--- a/run.py
+++ b/run.py
@@ -379,21 +379,12 @@ def run(
 
                 if os.path.isfile(filename_default):
                     data[key] = filename_default
-                    logging.info(
-                        "Setting up "
-                        + key
-                        + " in config file to"
-                        + str(data[key])
-                    )
                 else:
                     data[key] = None
-                    logging.info(
-                        "Setting up "
-                        + key
-                        + " in config file to"
-                        + str(data[key])
-                    )
 
+                logging.info(
+                    "Setting up " + key + " in config file to" + str(data[key])
+                )
             else:
                 # set missing variables to default value
                 logging.warning(

--- a/run.py
+++ b/run.py
@@ -375,7 +375,23 @@ def run(
                     + key
                     + " in config file or command line arguments. Setting to default value."
                 )
-                data[key] = os.path.join(data["datapath"], key + ".csv")
+                filename_default = os.path.join(data["datapath"], key + ".csv")
+
+                if os.path.isfile(filename_default):
+                    data[key] = filename_default
+                    logging.info(
+                        "Setting up "
+                        + key
+                        + " in config file to" + str(data[key])
+                    )
+                else:
+                    data[key] = None
+                    logging.info(
+                        "Setting up "
+                        + key
+                        + " in config file to" + str(data[key])
+                    )
+
             else:
                 # set missing variables to default value
                 logging.warning(

--- a/run.py
+++ b/run.py
@@ -382,14 +382,16 @@ def run(
                     logging.info(
                         "Setting up "
                         + key
-                        + " in config file to" + str(data[key])
+                        + " in config file to"
+                        + str(data[key])
                     )
                 else:
                     data[key] = None
                     logging.info(
                         "Setting up "
                         + key
-                        + " in config file to" + str(data[key])
+                        + " in config file to"
+                        + str(data[key])
                     )
 
             else:


### PR DESCRIPTION
Fixes #61 

In the default scenario (no `affinity` or `classes` flag with path provided) check that there is the default files `affinity.csv` or `classes.csv` in the datapath, if not define the variable to None.

For a missing affinity file but with `gamma`!=0 the code will fail with the following:

```
File "/Users/crangelsmith/Projects/affinity-vae/avae/loss.py", line 105, in __init__
    raise RuntimeError(
RuntimeError: Affinity matrix is needed to compute Affinity loss. Although you've set gamma, you have not provided --af/--affinity parameter.
```
which is expected. 