### PR TITLE
Fix limit bug

### DIFF
--- a/avae/config.py
+++ b/avae/config.py
@@ -17,7 +17,7 @@ FREQ_ACC = False
 FREQ_STA = False
 
 DEFAULT_RUN_CONFIGS = {
-    "limit": 1000,
+    "limit": None,
     "split": 20,
     "depth": 3,
     "channels": 64,

--- a/run.py
+++ b/run.py
@@ -372,8 +372,7 @@ def run(
 
     # Check for missing values and set to default values
     for key, val in data.items():
-
-        if val is None and key != "config_file":
+        if (val is None or val == "None") and key != "config_file":
             #  make sure data variables are provided
             if key == "data_path":
                 logging.error(


### PR DESCRIPTION
Variables set to `None` from config file were read as strings. This ensures variables that are `"None"` are also taken into consideration when filling out missing values.

Fixes #82 