### PR TITLE
Vis and save embeddings

### DIFF
--- a/avae/vis.py
+++ b/avae/vis.py
@@ -164,37 +164,41 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
         titley = "t-SNE-2"
     df["emb-x"], df["emb-y"] = np.array(lat_emb)[:, 0], np.array(lat_emb)[:, 1]
 
-    selection = altair.selection_multi(fields=["id"])
+    selection = altair.selection_multi(fields=["id"], empty="all")
+    selection_mode = altair.selection_multi(fields=["mode"],empty="all")
+
     color = altair.condition(
-        selection, altair.Color("id:N"), altair.value("lightgray")
+        (selection & selection_mode), altair.Color("id:N"), altair.value("lightgray")
     )
-    chart = (
+
+    scatter = (
         altair.Chart(df)
         .mark_point(size=100, opacity=0.5, filled=True)
         .encode(
             altair.X("emb-x", title=titlex),
             altair.Y("emb-y", title=titley),
-            # altair.Color('id', title='class'),
-            # altair.Opacity('mode', type='nominal',
-            #               scale=altair.Scale(domain=['train', 'val', 'test'],
-            #               range=['0.2', '0.4', '1.0']),
-            #               title='dataset'),
-            altair.Shape(
+           altair.Shape(
                 "mode",
                 scale=altair.Scale(range=["square", "circle", "triangle"]),
-                title="mode",
             ),
             altair.Tooltip(
                 ["id", "meta", "mode", "avg", "image"]
             ),  # *degrees_of_freedom, 'image']),
             color=color,
-        )
-        .configure_axis(labelFontSize=20, titleFontSize=20)
-        .configure_legend(titleFontSize=20, labelFontSize=18)
-        .interactive()
+        ).interactive()
         .properties(width=800, height=500)
         .add_selection(selection)
+        .add_selection(selection_mode)
+
     )
+
+    # Create interactive model name legend
+    legend_mode = altair.Chart(df).mark_point(size=100, opacity=0.5, filled=True).encode(
+        x=altair.X('mode:N', axis=altair.Axis(orient='bottom')),
+        shape=altair.Shape("mode", scale=altair.Scale(range=["square", "circle", "triangle"]), title="mode", legend=None),
+    ).add_selection(selection_mode)
+
+    chart = (legend_mode | scatter).configure_axis(labelFontSize=20, titleFontSize=20).configure_legend(labelFontSize=20, titleFontSize=20)
 
     if not os.path.exists("latents"):
         os.mkdir("latents")

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -202,6 +202,10 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
 
     if not os.path.exists("latents"):
         os.mkdir("latents")
+        # save latentspace and ids
+        df[[col for col in df if col.startswith(("lat", "id"))]].to_csv(
+            f"latents/latentspace_epoch_{epoch}.csv", index=False
+        )
     if embedding == "umap":
         chart.save(f"latents/plt_latent_embed_epoch_{epoch}_umap.html")
     elif embedding == "tsne":

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -165,10 +165,12 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
     df["emb-x"], df["emb-y"] = np.array(lat_emb)[:, 0], np.array(lat_emb)[:, 1]
 
     selection = altair.selection_multi(fields=["id"], empty="all")
-    selection_mode = altair.selection_multi(fields=["mode"],empty="all")
+    selection_mode = altair.selection_multi(fields=["mode"], empty="all")
 
     color = altair.condition(
-        (selection & selection_mode), altair.Color("id:N"), altair.value("lightgray")
+        (selection & selection_mode),
+        altair.Color("id:N"),
+        altair.value("lightgray"),
     )
 
     scatter = (
@@ -177,7 +179,7 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
         .encode(
             altair.X("emb-x", title=titlex),
             altair.Y("emb-y", title=titley),
-           altair.Shape(
+            altair.Shape(
                 "mode",
                 scale=altair.Scale(range=["square", "circle", "triangle"]),
             ),
@@ -185,20 +187,34 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
                 ["id", "meta", "mode", "avg", "image"]
             ),  # *degrees_of_freedom, 'image']),
             color=color,
-        ).interactive()
+        )
+        .interactive()
         .properties(width=800, height=500)
         .add_selection(selection)
         .add_selection(selection_mode)
-
     )
 
     # Create interactive model name legend
-    legend_mode = altair.Chart(df).mark_point(size=100, opacity=0.5, filled=True).encode(
-        x=altair.X('mode:N', axis=altair.Axis(orient='bottom')),
-        shape=altair.Shape("mode", scale=altair.Scale(range=["square", "circle", "triangle"]), title="mode", legend=None),
-    ).add_selection(selection_mode)
+    legend_mode = (
+        altair.Chart(df)
+        .mark_point(size=100, opacity=0.5, filled=True)
+        .encode(
+            x=altair.X("mode:N", axis=altair.Axis(orient="bottom")),
+            shape=altair.Shape(
+                "mode",
+                scale=altair.Scale(range=["square", "circle", "triangle"]),
+                title="mode",
+                legend=None,
+            ),
+        )
+        .add_selection(selection_mode)
+    )
 
-    chart = (legend_mode | scatter).configure_axis(labelFontSize=20, titleFontSize=20).configure_legend(labelFontSize=20, titleFontSize=20)
+    chart = (
+        (legend_mode | scatter)
+        .configure_axis(labelFontSize=20, titleFontSize=20)
+        .configure_legend(labelFontSize=20, titleFontSize=20)
+    )
 
     if not os.path.exists("latents"):
         os.mkdir("latents")

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -219,9 +219,9 @@ def dyn_latentembed_plot(df, epoch, embedding="umap"):
     if not os.path.exists("latents"):
         os.mkdir("latents")
         # save latentspace and ids
-        df[[col for col in df if col.startswith(("lat", "id"))]].to_csv(
-            f"latents/latentspace_epoch_{epoch}.csv", index=False
-        )
+    df[[col for col in df if col.startswith(("lat", "id"))]].to_csv(
+        f"latents/latentspace_epoch_{epoch}.csv", index=False
+    )
     if embedding == "umap":
         chart.save(f"latents/plt_latent_embed_epoch_{epoch}_umap.html")
     elif embedding == "tsne":


### PR DESCRIPTION
- Fixes #86 
- Saves latent space 

Training/val/test legend is interactive together with dots in scatter plot. I tried to make both training and classes legends interactive but reached some unexpected [known behaviours](https://github.com/altair-viz/altair/issues/1759) that I thought it was not worth spending too much time on.  

Example here:

1. Default view

<img width="1115" alt="Screenshot 2023-05-10 at 09 41 41" src="https://github.com/alan-turing-institute/affinity-vae/assets/11162074/d92aeadd-7d83-4eac-95cf-0c026f63def0">


2. Click on the scatter plot, it will select the class and data type given where you click

<img width="1140" alt="Screenshot 2023-05-10 at 09 41 18" src="https://github.com/alan-turing-institute/affinity-vae/assets/11162074/80ad6e3b-fac4-4adf-91b8-347fecc656e5">

3 Use the interactive legend to change between data types for that class (ignore the sound symbol :-) ) . 

<img width="1122" alt="Screenshot 2023-05-10 at 09 41 08" src="https://github.com/alan-turing-institute/affinity-vae/assets/11162074/d67dd42b-e86f-4484-a794-2f8846ee4a21">
<img width="1139" alt="Screenshot 2023-05-10 at 09 41 25" src="https://github.com/alan-turing-institute/affinity-vae/assets/11162074/627b586a-990e-4127-ab47-d2b492220abb">



 