### PR TITLE
Lowpass

### DIFF
--- a/avae/config.py
+++ b/avae/config.py
@@ -73,4 +73,7 @@ DEFAULT_RUN_CONFIGS = {
     "gaussian_blur": False,
     "normalise": False,
     "shift_min": False,
+    "bandpass": False,
+    "bp_low": 0,
+    "bp_high": 10,
 }

--- a/avae/data.py
+++ b/avae/data.py
@@ -62,6 +62,12 @@ def load_data(
         In True, the input data is normalised before being passed to the model.
     shift_min: bool
         If True, the minimum value of the input data is shifted to 0 and maximum to 1.
+    bandpass: bool
+        If True, a band pass filter is applied to the data before it is used for training. For this, you must specify the lower and upper frequency band in (Hz).
+    bp_low:
+        lower frequency threshhold for the band pass filter
+    bp_high:
+        higher frequency threshhold for the band pass filter
 
 
     Returns

--- a/avae/data.py
+++ b/avae/data.py
@@ -261,7 +261,7 @@ class ProteinDataset(Dataset):
             )
         if self.bandpass:
             print(
-                "Data Transformation :BandPasss filter is applied to input with lower threshhold of {bp_low} and higher threshhold of {bp_high}",
+                f"Data Transformation :BandPasss filter is applied to input with lower threshhold of {bp_low} and higher threshhold of {bp_high}",
                 flush=True,
             )
 
@@ -311,25 +311,13 @@ class ProteinDataset(Dataset):
         x = x.unsqueeze(0)
 
         if self.shift_min:
-            print(
-                "Data Transformation : Shift the minimum of the data to one zero and the maximum to one",
-                flush=True,
-            )
             x = (x - x.min()) / (x.max() - x.min())
 
         if self.gaussian_blur:
-            print(
-                "Data Transformation : GaussianBlur is applied to the images",
-                flush=True,
-            )
             T = transforms.GaussianBlur(3, sigma=(0.08, 10.0))
             x = T(x)
 
         if self.normalise:
-            print(
-                "Data Transformation : Normalisation is applied to the images",
-                flush=True,
-            )
             T = transforms.Normalize(0, 1, inplace=False)
             x = T(x)
 

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -22,6 +22,9 @@ def evaluate(
     gaussian_blur,
     normalise,
     shift_min,
+    bandpass,
+    bp_low,
+    bp_high,
 ):
     """Function for evaluating the model. Loads the data, model and runs the evaluation. Saves the results of the
     evaluation in the plot and latents directories.
@@ -66,6 +69,9 @@ def evaluate(
         gaussian_blur=gaussian_blur,
         normalise=normalise,
         shift_min=shift_min,
+        bandpass=bandpass,
+        bp_low=bp_low,
+        bp_high=bp_high,
     )
 
     # ############################### MODEL ###############################

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -54,7 +54,12 @@ def evaluate(
         In True, the input data is normalised before being passed to the model.
     shift_min: bool
         If True, the input data is shifted to have a minimum value of 0 and max 1.
-
+    bandpass: bool
+        If True, a band pass filter is applied to the data before it is used for training. For this, you must specify the lower and upper frequency band in (Hz).
+    bp_low:
+        lower frequency threshhold for the band pass filter
+    bp_high:
+        higher frequency threshhold for the band pass filter
 
     """
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -123,6 +123,13 @@ def train(
         In True, the input data is normalised before being passed to the model.
     shift_min: bool
         If True, the input data is shifted to have a minimum value of 0 and max of 1.
+    bandpass: bool
+        If True, a band pass filter is applied to the data before it is used for training. For this, you must specify the lower and upper frequency band in (Hz).
+    bp_low:
+        lower frequency threshhold for the band pass filter
+    bp_high:
+        higher frequency threshhold for the band pass filter
+
     """
     torch.manual_seed(42)
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -51,6 +51,9 @@ def train(
     gaussian_blur,
     normalise,
     shift_min,
+    bandpass,
+    bp_low,
+    bp_high,
 ):
     """Function to train an AffinityVAE model. The inputs are training configuration parameters. In this function the
     data is loaded, selected and split into training, validation and test sets, the model is initialised and trained
@@ -143,6 +146,9 @@ def train(
         gaussian_blur=gaussian_blur,
         normalise=normalise,
         shift_min=shift_min,
+        bandpass=bandpass,
+        bp_low=bp_low,
+        bp_high=bp_high,
     )
     dshape = list(trains)[0][0].shape[-3:]
     pose = not (pose_dims == 0)

--- a/run.py
+++ b/run.py
@@ -451,7 +451,7 @@ logging.basicConfig(
     type=bool,
     default=None,
     is_flag=True,
-    help="Applies the band pass filter. For this, you must specify the lower and upper frequency band in (Hz). ",
+    help="If True, a band pass filter is applied to the data before it is used for training. For this, you must specify the lower and upper frequency band in (Hz). ",
 )
 @click.option(
     "--bp_low",

--- a/run.py
+++ b/run.py
@@ -445,6 +445,28 @@ logging.basicConfig(
     is_flag=True,
     help="Shift the minimum of the data to one zero and the maximum to one",
 )
+@click.option(
+    "--bandpass",
+    "-sftm",
+    type=bool,
+    default=None,
+    is_flag=True,
+    help="Applies the band pass filter. For this, you must specify the lower and upper frequency band in (Hz). ",
+)
+@click.option(
+    "--bp_low",
+    "-bplow",
+    type=int,
+    default=None,
+    help="lower frequency threshhold for  the band pass filter",
+)
+@click.option(
+    "--bp_high",
+    "-bphigh",
+    type=int,
+    default=None,
+    help="lower frequency threshhold for the band pass filter",
+)
 def run(
     config_file,
     datapath,
@@ -504,6 +526,9 @@ def run(
     gaussian_blur,
     normalise,
     shift_min,
+    bandpass,
+    bp_low,
+    bp_high,
 ):
 
     warnings.simplefilter("ignore", FutureWarning)
@@ -689,6 +714,9 @@ def run(
                 gaussian_blur=data["gaussian_blur"],
                 normalise=data["normalise"],
                 shift_min=data["shift_min"],
+                bandpass=data["bandpass"],
+                bp_low=data["bp_low"],
+                bp_high=data["bp_high"],
             )
         else:
             evaluate(
@@ -703,6 +731,9 @@ def run(
                 gaussian_blur=data["gaussian_blur"],
                 normalise=data["normalise"],
                 shift_min=data["shift_min"],
+                bandpass=data["bandpass"],
+                bp_low=data["bp_low"],
+                bp_high=data["bp_high"],
             )
             # TODO also make sure image is correct size, maybe in dataloader?
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -43,6 +43,9 @@ class DataTest(unittest.TestCase):
             gaussian_blur=True,
             normalise=True,
             shift_min=True,
+            bandpass=True,
+            bp_low=0,
+            bp_high=10,
         )
         print(os.getcwd())
 
@@ -75,6 +78,9 @@ class DataTest(unittest.TestCase):
             gaussian_blur=True,
             normalise=True,
             shift_min=True,
+            bandpass=True,
+            bp_low=0,
+            bp_high=10,
         )
 
         # test load_data

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -56,6 +56,9 @@ class TrainEvalTest(unittest.TestCase):
             "gaussian_blur": True,
             "normalise": True,
             "shift_min": True,
+            "bandpass": True,
+            "bp_low": 0,
+            "bp_high": 10,
         }
 
         config.FREQ_ACC = 5
@@ -116,6 +119,9 @@ class TrainEvalTest(unittest.TestCase):
             gaussian_blur=self.data["gaussian_blur"],
             normalise=self.data["normalise"],
             shift_min=self.data["shift_min"],
+            bandpass=self.data["bandpass"],
+            bp_low=self.data["bp_low"],
+            bp_high=self.data["bp_high"],
         )
         n_dir_train = len(next(os.walk(temp_dir.name))[1])
         n_plots_train = len(os.listdir(os.path.join(temp_dir.name, "plots")))
@@ -141,6 +147,9 @@ class TrainEvalTest(unittest.TestCase):
             gaussian_blur=self.data["gaussian_blur"],
             normalise=self.data["normalise"],
             shift_min=self.data["shift_min"],
+            bandpass=self.data["bandpass"],
+            bp_low=self.data["bp_low"],
+            bp_high=self.data["bp_high"],
         )
 
         n_plots_eval = len(os.listdir(os.path.join(temp_dir.name, "plots")))
@@ -193,6 +202,9 @@ class TrainEvalTest(unittest.TestCase):
             gaussian_blur=self.data["gaussian_blur"],
             normalise=self.data["normalise"],
             shift_min=self.data["shift_min"],
+            bandpass=self.data["bandpass"],
+            bp_low=self.data["bp_low"],
+            bp_high=self.data["bp_high"],
         )
 
         n_dir_train = len(next(os.walk(temp_dir.name))[1])
@@ -219,6 +231,9 @@ class TrainEvalTest(unittest.TestCase):
             gaussian_blur=self.data["gaussian_blur"],
             normalise=self.data["normalise"],
             shift_min=self.data["shift_min"],
+            bandpass=self.data["bandpass"],
+            bp_low=self.data["bp_low"],
+            bp_high=self.data["bp_high"],
         )
 
         n_plots_eval = len(os.listdir(os.path.join(temp_dir.name, "plots")))


### PR DESCRIPTION
This PR addresses #145.

WARNING : It makes training slow as it performs Fourier transform and reverse on each dataset. A better implementation of this would be to apply a band pass on the whole tomogram and create vowels in the dataloader.  For this I will need to implement the tomogram dataloader. For the moment, I think it is ok to have this as a feature even if it is slow. We can include this in the documentation. 