### PR TITLE
Bugfix

### DIFF
--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -259,6 +259,7 @@ def evaluate(
             mode="_eval",
         )
 
+        metas = os.path.basename(meta)
         # save metadata with evaluation data
         meta_df.to_pickle(
             os.path.join("states", metas.split(".")[0] + "_eval.pkl")


### PR DESCRIPTION
Prevents the code from breaking when meta for evaluation is provided and 'metas' is not defined