### PR TITLE
F1 bugfix 

### DIFF
--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -108,7 +108,11 @@ def evaluate(
     if meta is None:
         if collect_meta:
             metas = sorted(
-                [f for f in os.listdir("states") if ".pkl" in f],
+                [
+                    f
+                    for f in os.listdir("states")
+                    if ".pkl" in f and "eval" not in f
+                ],
                 key=lambda x: int(x.split("_")[2][1:]),
             )[-1]
             meta = os.path.join("states", metas)

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -113,6 +113,7 @@ def evaluate(
             )[-1]
             meta = os.path.join("states", metas)
 
+    logging.info("Loading model from: {}".format(meta))
     meta_df = pd.read_pickle(meta)
 
     # create holders for latent spaces and labels

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -93,7 +93,8 @@ def evaluate(
             )[-1]
             state = os.path.join("states", state)
 
-    fname = state.split(".")[0].split("_")
+    s = os.path.basename(state)
+    fname = s.split(".")[0].split("_")
     pose_dims = fname[3]
 
     logging.info("Loading model from: {}".format(state))

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -264,6 +264,7 @@ def evaluate(
             classes,
             mode="_eval",
         )
+        logging.info('Saving meta files with evaluation data.')
 
         metas = os.path.basename(meta)
         # save metadata with evaluation data

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -242,7 +242,7 @@ def evaluate(
             )
 
         # visualise accuracy
-        train_acc, val_acc, ypred_train, ypred_val = accuracy(
+        train_acc, val_acc, val_acc_selected, ypred_train, ypred_val = accuracy(
             latents_training,
             np.array(latents_training_id),
             x_test,
@@ -250,8 +250,8 @@ def evaluate(
             classifier=classifier,
         )
         logging.info(
-            "\n------------------->>> Accuracy: Train: %f | Val: %f\n"
-            % (train_acc, val_acc)
+            "\n------------------->>> Accuracy: Train: %f | Val : %f | Val with unseen labels: %f\n"
+            % (train_acc, val_acc_selected, val_acc)
         )
         vis.accuracy_plot(
             np.array(latents_training_id),

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -264,7 +264,7 @@ def evaluate(
             classes,
             mode="_eval",
         )
-        logging.info('Saving meta files with evaluation data.')
+        logging.info("Saving meta files with evaluation data.")
 
         metas = os.path.basename(meta)
         # save metadata with evaluation data

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -242,7 +242,13 @@ def evaluate(
             )
 
         # visualise accuracy
-        train_acc, val_acc, val_acc_selected, ypred_train, ypred_val = accuracy(
+        (
+            train_acc,
+            val_acc,
+            val_acc_selected,
+            ypred_train,
+            ypred_val,
+        ) = accuracy(
             latents_training,
             np.array(latents_training_id),
             x_test,

--- a/avae/train.py
+++ b/avae/train.py
@@ -18,44 +18,44 @@ from .utils_learning import add_meta, pass_batch, set_device
 
 
 def train(
-        datapath,
-        datatype,
-        restart,
-        state,
-        lim,
-        splt,
-        batch_s,
-        no_val_drop,
-        affinity,
-        classes,
-        collect_meta,
-        epochs,
-        channels,
-        depth,
-        lat_dims,
-        pose_dims,
-        learning,
-        beta_load,
-        beta_min,
-        beta_max,
-        beta_cycle,
-        beta_ratio,
-        cyc_method_beta,
-        gamma_load,
-        gamma_min,
-        gamma_max,
-        gamma_cycle,
-        gamma_ratio,
-        cyc_method_gamma,
-        recon_fn,
-        use_gpu,
-        model,
-        opt_method,
-        gaussian_blur,
-        normalise,
-        shift_min,
-        tensorboard,
-        classifier,
+    datapath,
+    datatype,
+    restart,
+    state,
+    lim,
+    splt,
+    batch_s,
+    no_val_drop,
+    affinity,
+    classes,
+    collect_meta,
+    epochs,
+    channels,
+    depth,
+    lat_dims,
+    pose_dims,
+    learning,
+    beta_load,
+    beta_min,
+    beta_max,
+    beta_cycle,
+    beta_ratio,
+    cyc_method_beta,
+    gamma_load,
+    gamma_min,
+    gamma_max,
+    gamma_cycle,
+    gamma_ratio,
+    cyc_method_gamma,
+    recon_fn,
+    use_gpu,
+    model,
+    opt_method,
+    gaussian_blur,
+    normalise,
+    shift_min,
+    tensorboard,
+    classifier,
 ):
     """Function to train an AffinityVAE model. The inputs are training configuration parameters. In this function the
     data is loaded, selected and split into training, validation and test sets, the model is initialised and trained
@@ -235,14 +235,14 @@ def train(
         # If a path for loading the beta array is not provided,
         # create it given the input
         beta_arr = (
-                cyc_annealing(
-                    epochs,
-                    cyc_method_beta,
-                    n_cycle=beta_cycle,
-                    ratio=beta_ratio,
-                ).var
-                * (beta_max - beta_min)
-                + beta_min
+            cyc_annealing(
+                epochs,
+                cyc_method_beta,
+                n_cycle=beta_cycle,
+                ratio=beta_ratio,
+            ).var
+            * (beta_max - beta_min)
+            + beta_min
         )
     else:
         beta_arr = np.load(beta_load)
@@ -253,9 +253,9 @@ def train(
             )
 
     if (
-            gamma_max == 0
-            and cyc_method_gamma != "flat"
-            and gamma_load is not None
+        gamma_max == 0
+        and cyc_method_gamma != "flat"
+        and gamma_load is not None
     ):
         raise RuntimeError(
             "The maximum value for gamma is set to 0, it is not possible to"
@@ -267,14 +267,14 @@ def train(
         # If a path for loading the gamma array is not provided,
         # create it given the input
         gamma_arr = (
-                cyc_annealing(
-                    epochs,
-                    cyc_method_gamma,
-                    n_cycle=gamma_cycle,
-                    ratio=gamma_ratio,
-                ).var
-                * (gamma_max - gamma_min)
-                + gamma_min
+            cyc_annealing(
+                epochs,
+                cyc_method_gamma,
+                n_cycle=gamma_cycle,
+                ratio=gamma_ratio,
+            ).var
+            * (gamma_max - gamma_min)
+            + gamma_min
         )
     else:
         gamma_arr = np.load(gamma_load)
@@ -440,7 +440,7 @@ def train(
 
         if writer:
             for i, loss_name in enumerate(
-                    ["Loss", "Recon loss", "KLdiv loss", "Affin loss"]
+                ["Loss", "Recon loss", "KLdiv loss", "Affin loss"]
             ):
                 writer.add_scalar(loss_name, v_history[-1][i], epoch)
 
@@ -636,15 +636,15 @@ def train(
             if not os.path.exists("states"):
                 os.mkdir("states")
             mname = (
-                    "avae_"
-                    + str(timestamp)
-                    + "_E"
-                    + str(epoch)
-                    + "_"
-                    + str(lat_dims)
-                    + "_"
-                    + str(pose_dims)
-                    + ".pt"
+                "avae_"
+                + str(timestamp)
+                + "_E"
+                + str(epoch)
+                + "_"
+                + str(lat_dims)
+                + "_"
+                + str(pose_dims)
+                + ".pt"
             )
 
             logging.info(
@@ -668,15 +668,15 @@ def train(
 
             if collect_meta:
                 filename = (
-                        "meta_"
-                        + str(timestamp)
-                        + "_E"
-                        + str(epoch)
-                        + "_"
-                        + str(lat_dims)
-                        + "_"
-                        + str(pose_dims)
-                        + ".pkl"
+                    "meta_"
+                    + str(timestamp)
+                    + "_E"
+                    + str(epoch)
+                    + "_"
+                    + str(lat_dims)
+                    + "_"
+                    + str(pose_dims)
+                    + ".pkl"
                 )
                 meta_df.to_pickle(os.path.join("states", filename))
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -18,44 +18,44 @@ from .utils_learning import add_meta, pass_batch, set_device
 
 
 def train(
-    datapath,
-    datatype,
-    restart,
-    state,
-    lim,
-    splt,
-    batch_s,
-    no_val_drop,
-    affinity,
-    classes,
-    collect_meta,
-    epochs,
-    channels,
-    depth,
-    lat_dims,
-    pose_dims,
-    learning,
-    beta_load,
-    beta_min,
-    beta_max,
-    beta_cycle,
-    beta_ratio,
-    cyc_method_beta,
-    gamma_load,
-    gamma_min,
-    gamma_max,
-    gamma_cycle,
-    gamma_ratio,
-    cyc_method_gamma,
-    recon_fn,
-    use_gpu,
-    model,
-    opt_method,
-    gaussian_blur,
-    normalise,
-    shift_min,
-    tensorboard,
-    classifier,
+        datapath,
+        datatype,
+        restart,
+        state,
+        lim,
+        splt,
+        batch_s,
+        no_val_drop,
+        affinity,
+        classes,
+        collect_meta,
+        epochs,
+        channels,
+        depth,
+        lat_dims,
+        pose_dims,
+        learning,
+        beta_load,
+        beta_min,
+        beta_max,
+        beta_cycle,
+        beta_ratio,
+        cyc_method_beta,
+        gamma_load,
+        gamma_min,
+        gamma_max,
+        gamma_cycle,
+        gamma_ratio,
+        cyc_method_gamma,
+        recon_fn,
+        use_gpu,
+        model,
+        opt_method,
+        gaussian_blur,
+        normalise,
+        shift_min,
+        tensorboard,
+        classifier,
 ):
     """Function to train an AffinityVAE model. The inputs are training configuration parameters. In this function the
     data is loaded, selected and split into training, validation and test sets, the model is initialised and trained
@@ -235,14 +235,14 @@ def train(
         # If a path for loading the beta array is not provided,
         # create it given the input
         beta_arr = (
-            cyc_annealing(
-                epochs,
-                cyc_method_beta,
-                n_cycle=beta_cycle,
-                ratio=beta_ratio,
-            ).var
-            * (beta_max - beta_min)
-            + beta_min
+                cyc_annealing(
+                    epochs,
+                    cyc_method_beta,
+                    n_cycle=beta_cycle,
+                    ratio=beta_ratio,
+                ).var
+                * (beta_max - beta_min)
+                + beta_min
         )
     else:
         beta_arr = np.load(beta_load)
@@ -253,9 +253,9 @@ def train(
             )
 
     if (
-        gamma_max == 0
-        and cyc_method_gamma != "flat"
-        and gamma_load is not None
+            gamma_max == 0
+            and cyc_method_gamma != "flat"
+            and gamma_load is not None
     ):
         raise RuntimeError(
             "The maximum value for gamma is set to 0, it is not possible to"
@@ -267,14 +267,14 @@ def train(
         # If a path for loading the gamma array is not provided,
         # create it given the input
         gamma_arr = (
-            cyc_annealing(
-                epochs,
-                cyc_method_gamma,
-                n_cycle=gamma_cycle,
-                ratio=gamma_ratio,
-            ).var
-            * (gamma_max - gamma_min)
-            + gamma_min
+                cyc_annealing(
+                    epochs,
+                    cyc_method_gamma,
+                    n_cycle=gamma_cycle,
+                    ratio=gamma_ratio,
+                ).var
+                * (gamma_max - gamma_min)
+                + gamma_min
         )
     else:
         gamma_arr = np.load(gamma_load)
@@ -440,7 +440,7 @@ def train(
 
         if writer:
             for i, loss_name in enumerate(
-                ["Loss", "Recon loss", "KLdiv loss", "Affin loss"]
+                    ["Loss", "Recon loss", "KLdiv loss", "Affin loss"]
             ):
                 writer.add_scalar(loss_name, v_history[-1][i], epoch)
 
@@ -471,7 +471,7 @@ def train(
 
         # visualise accuracy: confusion and F1 scores
         if config.VIS_ACC and (epoch + 1) % config.FREQ_ACC == 0:
-            train_acc, val_acc, ypred_train, ypred_val = accuracy(
+            train_acc, val_acc, _, ypred_train, ypred_val = accuracy(
                 x_train, y_train, x_val, y_val, classifier=classifier
             )
 
@@ -636,15 +636,15 @@ def train(
             if not os.path.exists("states"):
                 os.mkdir("states")
             mname = (
-                "avae_"
-                + str(timestamp)
-                + "_E"
-                + str(epoch)
-                + "_"
-                + str(lat_dims)
-                + "_"
-                + str(pose_dims)
-                + ".pt"
+                    "avae_"
+                    + str(timestamp)
+                    + "_E"
+                    + str(epoch)
+                    + "_"
+                    + str(lat_dims)
+                    + "_"
+                    + str(pose_dims)
+                    + ".pt"
             )
 
             logging.info(
@@ -667,17 +667,16 @@ def train(
             )
 
             if collect_meta:
-
                 filename = (
-                    "meta_"
-                    + str(timestamp)
-                    + "_E"
-                    + str(epoch)
-                    + "_"
-                    + str(lat_dims)
-                    + "_"
-                    + str(pose_dims)
-                    + ".pkl"
+                        "meta_"
+                        + str(timestamp)
+                        + "_E"
+                        + str(epoch)
+                        + "_"
+                        + str(lat_dims)
+                        + "_"
+                        + str(pose_dims)
+                        + ".pkl"
                 )
                 meta_df.to_pickle(os.path.join("states", filename))
 

--- a/avae/utils.py
+++ b/avae/utils.py
@@ -56,7 +56,8 @@ def accuracy(x_train, y_train, x_val, y_val, classifier="NN"):
     classes_list_training = np.unique(y_train)
     if np.setdiff1d(classes_list_training, np.unique(y_val)).size > 0:
         logging.info(
-            f"Class {np.setdiff1d(classes_list_training, np.unique(y_val))}  was unseen in training data. Computing accuracy for sets of seen and unseen data")
+            f"Class {np.setdiff1d(classes_list_training, np.unique(y_val))}  was unseen in training data. Computing accuracy for sets of seen and unseen data"
+        )
 
     index = np.argwhere(np.isin(y_val, classes_list_training)).ravel()
 
@@ -112,10 +113,11 @@ def accuracy(x_train, y_train, x_val, y_val, classifier="NN"):
     y_pred_train = clf.predict(x_train)
     y_pred_val = clf.predict(x_val)
 
-
     train_acc = metrics.accuracy_score(y_train, y_pred_train)
     val_acc = metrics.accuracy_score(y_val, y_pred_val)
-    val_acc_selected = metrics.accuracy_score(np.array(y_val)[index].tolist(), np.array(y_pred_val)[index].tolist())
+    val_acc_selected = metrics.accuracy_score(
+        np.array(y_val)[index].tolist(), np.array(y_pred_val)[index].tolist()
+    )
 
     y_pred_train = le.inverse_transform(y_pred_train)
     y_pred_val = le.inverse_transform(y_pred_val)

--- a/avae/utils.py
+++ b/avae/utils.py
@@ -40,6 +40,8 @@ def accuracy(x_train, y_train, x_val, y_val, classifier="NN"):
         Training accuracy.
     val_acc: float
         Validation accuracy.
+    val_acc_selected: float
+        Validation accuracy calculated only for labels existing in the training set (this is useful in evaluation).
     y_pred_train: np.array
         Predicted training labels.
     y_pred_val: np.array
@@ -50,6 +52,13 @@ def accuracy(x_train, y_train, x_val, y_val, classifier="NN"):
     labs = np.unique(np.concatenate((y_train, y_val)))
     le = preprocessing.LabelEncoder()
     le.fit(labs)
+
+    classes_list_training = np.unique(y_train)
+    if np.setdiff1d(classes_list_training, np.unique(y_val)).size > 0:
+        logging.info(
+            f"Class {np.setdiff1d(classes_list_training, np.unique(y_val))}  was unseen in training data. Computing accuracy for sets of seen and unseen data")
+
+    index = np.argwhere(np.isin(y_val, classes_list_training)).ravel()
 
     y_train = le.transform(y_train)
     y_val = le.transform(y_val)
@@ -102,13 +111,16 @@ def accuracy(x_train, y_train, x_val, y_val, classifier="NN"):
 
     y_pred_train = clf.predict(x_train)
     y_pred_val = clf.predict(x_val)
+
+
     train_acc = metrics.accuracy_score(y_train, y_pred_train)
     val_acc = metrics.accuracy_score(y_val, y_pred_val)
+    val_acc_selected = metrics.accuracy_score(np.array(y_val)[index].tolist(), np.array(y_pred_val)[index].tolist())
 
     y_pred_train = le.inverse_transform(y_pred_train)
     y_pred_val = le.inverse_transform(y_pred_val)
 
-    return train_acc, val_acc, y_pred_train, y_pred_val
+    return train_acc, val_acc, val_acc_selected, y_pred_train, y_pred_val
 
 
 def create_grid_for_plotting(rows, columns, dsize, padding=0):

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -573,7 +573,7 @@ def accuracy_plot(
 
         plt.tight_layout()
         plt.title(
-            "Average accuracy at epoch {}: {:.1f}%".format(
+            "Average accuracy at epoch {}: {:.3f}%".format(
                 epoch, np.mean(avg_accuracy) * 100
             ),
             fontsize=10,
@@ -603,7 +603,7 @@ def accuracy_plot(
 
         plt.tight_layout()
         plt.title(
-            "Average accuracy at epoch {}: {:.1f}%".format(
+            "Average accuracy at epoch {}: {:.3f}%".format(
                 epoch, np.mean(avg_accuracy) * 100
             ),
             fontsize=12,

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -742,7 +742,7 @@ def f1_plot(
 
     if np.setdiff1d(classes_list_eval, classes_list).size > 0:
         logging.info(
-            f"Class {np.setdiff1d(classes_list_eval, classes_list)} wont be used to compute F1 values as it was unseen in training data."
+            f"Class {np.setdiff1d(classes_list_eval, classes_list)} will not be used to compute F1 values as it was unseen in training data."
         )
 
         index = np.argwhere(np.isin(y_val, classes_list)).ravel()

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -105,11 +105,11 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 32)
+        self.assertEqual(n_plots_train, 30)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
 
-        self.assertEqual(n_plots_eval, 50)
+        self.assertEqual(n_plots_eval, 48)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -126,10 +126,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 32)
+        self.assertEqual(n_plots_train, 30)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 50)
+        self.assertEqual(n_plots_eval, 48)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -152,10 +152,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 30)
+        self.assertEqual(n_plots_train, 28)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 47)
+        self.assertEqual(n_plots_eval, 45)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -88,7 +88,7 @@ class TrainEvalTest(unittest.TestCase):
         config.VIS_DIS = True
         config.VIS_POS = True
         config.VIS_HIS = True
-        config.VIS_CON = True
+        config.VIS_CON = False
         config.VIS_AFF = True
         config.VIS_SIM = True
 


### PR DESCRIPTION
Breaking down PR #207 (which will become obsolete)

- [x] In evaluation only calculate eval for particles seen in training (#205)
- [x] Fixed bug that broke evaluation when an evaluation meta file already existed in `states` (#208)
- [x] Fixed issue with reading states from non relative paths.(#208)
- [x] Turns off confidence plots in tests