### PR TITLE
Early stopping

### DIFF
--- a/avae/config.py
+++ b/avae/config.py
@@ -23,6 +23,8 @@ FREQ_SIM = 10
 FREQ_EVAL = 10
 FREQ_STA = 10
 
+MIN_TRAIN = 0.5
+
 DEFAULT_RUN_CONFIGS = {
     "limit": None,
     "restart": False,
@@ -87,4 +89,5 @@ DEFAULT_RUN_CONFIGS = {
     "debug": False,
     "early_stopping": False,
     "es_trigger": "all",
+    "es_patience": 10,
 }

--- a/avae/config.py
+++ b/avae/config.py
@@ -88,7 +88,7 @@ DEFAULT_RUN_CONFIGS = {
     "new_out": False,
     "debug": False,
     "early_stopping": False,
-    "es_trigger": "all",
+    "es_trigger": "total_loss",
     "es_patience": 10,
     "minimum_train": MIN_TRAIN,
 }

--- a/avae/config.py
+++ b/avae/config.py
@@ -85,4 +85,6 @@ DEFAULT_RUN_CONFIGS = {
     "datatype": "mrc",
     "new_out": False,
     "debug": False,
+    "early_stopping": False,
+    "es_trigger": "all",
 }

--- a/avae/config.py
+++ b/avae/config.py
@@ -90,4 +90,5 @@ DEFAULT_RUN_CONFIGS = {
     "early_stopping": False,
     "es_trigger": "all",
     "es_patience": 10,
+    "minimum_train": MIN_TRAIN,
 }

--- a/avae/data.py
+++ b/avae/data.py
@@ -302,7 +302,7 @@ class Dataset_reader(Dataset):
 
     def voxel_transformation(self, x):
 
-        if self.rescale is not None:
+        if self.rescale:
             sh = tuple([self.rescale / s for s in x.shape])
             x = zoom(x, sh)
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -708,7 +708,7 @@ def train(
 
             logging.info(f"Saved meta file : {filename} for evaluation \n")
 
-        if stop and early_stopping_trigger:
+        if stop and early_stopping:
             logging.info("Early stopping at epoch %d" % (epoch + 1))
             break
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -15,6 +16,8 @@ from .model_a import AffinityVAE as AffinityVAE_A
 from .model_b import AffinityVAE as AffinityVAE_B
 from .utils import accuracy
 from .utils_learning import add_meta, early_stopping, pass_batch, set_device
+
+warnings.filterwarnings("ignore", message=".*The 'nopython' keyword.*")
 
 
 def train(
@@ -435,7 +438,10 @@ def train(
                 )
             )
 
-        early_stop = early_stopping(v_history, 10)
+        if beta_arr[epoch] == beta_max and gamma_arr[epoch] == gamma_max:
+            early_stop = early_stopping([loss[0] for loss in v_history], 10)
+        else:
+            early_stop = False
 
         v_history[-1] /= len(vals)
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -63,6 +63,7 @@ def train(
     classifier,
     early_stopping,
     es_loss_trigger,
+    es_patience,
 ):
     """Function to train an AffinityVAE model. The inputs are training configuration parameters. In this function the
     data is loaded, selected and split into training, validation and test sets, the model is initialised and trained
@@ -142,6 +143,9 @@ def train(
         If True, the training will stop when the validation loss stops improving.
     es_loss_trigger: str
         The loss to use for early stopping. Can be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'."
+    es_patioence: int
+        Number of previous epochs to use on the evaluation of loss improvement.
+
     """
     torch.manual_seed(42)
 
@@ -442,9 +446,14 @@ def train(
             )
         )
 
-        if beta_arr[epoch] == beta_max and gamma_arr[epoch] == gamma_max:
+        # make sure parameters are not cycling and that 20% of the epochs have run.
+        if (
+            beta_arr[epoch] == beta_max
+            and gamma_arr[epoch] == gamma_max
+            and epoch > epochs * config.MIN_TRAIN
+        ):
             stop = early_stopping_trigger(
-                v_history, 10, trigger=es_loss_trigger
+                v_history, patience=es_patience, trigger=es_loss_trigger
             )
         else:
             stop = False

--- a/avae/train.py
+++ b/avae/train.py
@@ -439,7 +439,7 @@ def train(
             )
 
         if beta_arr[epoch] == beta_max and gamma_arr[epoch] == gamma_max:
-            early_stop = early_stopping([loss[0] for loss in v_history], 10)
+            early_stop = early_stopping(v_history, 10)
         else:
             early_stop = False
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -311,8 +311,8 @@ def train(
     stopper = EarlyStopping(
         loss_type=es_loss_trigger,
         patience=es_patience,
-        max_delta=1,
-        max_divergence=20,
+        max_delta=0.01,
+        max_divergence=0.2,
         min_epochs=config.MIN_TRAIN * epochs,
     )
     # ########################## TRAINING LOOP ################################

--- a/avae/train.py
+++ b/avae/train.py
@@ -368,19 +368,17 @@ def train(
                 mode="trn",
             )
 
-            logging.info(
-                "Training : Epoch: [%d/%d] | Batch: [%d/%d] | Loss: %f | Recon: %f | "
-                "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
-                % (
-                    epoch + 1,
-                    epochs,
-                    b + 1,
-                    len(trains),
-                    *t_history[-1],
-                    beta_arr[epoch],
-                    gamma_arr[epoch],
-                )
+        logging.info(
+            "Training : Epoch: [%d/%d] | Loss: %f | Recon: %f | "
+            "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
+            % (
+                epoch + 1,
+                epochs,
+                *t_history[-1],
+                beta_arr[epoch],
+                gamma_arr[epoch],
             )
+        )
 
         t_history[-1] /= len(trains)
 
@@ -424,19 +422,17 @@ def train(
                 mode="val",
             )
 
-            logging.info(
-                "Validation : Epoch: [%d/%d] | Batch: [%d/%d] | Loss: %f | Recon: %f | "
-                "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
-                % (
-                    epoch + 1,
-                    epochs,
-                    b + 1,
-                    len(vals),
-                    *v_history[-1],
-                    beta_arr[epoch],
-                    gamma_arr[epoch],
-                )
+        logging.info(
+            "Validation : Epoch: [%d/%d] | Loss: %f | Recon: %f | "
+            "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
+            % (
+                epoch + 1,
+                epochs,
+                *v_history[-1],
+                beta_arr[epoch],
+                gamma_arr[epoch],
             )
+        )
 
         if beta_arr[epoch] == beta_max and gamma_arr[epoch] == gamma_max:
             early_stop = early_stopping(v_history, 10)

--- a/avae/train.py
+++ b/avae/train.py
@@ -382,6 +382,8 @@ def train(
                 mode="trn",
             )
 
+        t_history[-1] /= len(trains)
+
         logging.info(
             "Training : Epoch: [%d/%d] | Loss: %f | Recon: %f | "
             "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
@@ -393,8 +395,6 @@ def train(
                 gamma_arr[epoch],
             )
         )
-
-        t_history[-1] /= len(trains)
 
         # ########################## VAL ######################################
         vae.eval()
@@ -436,6 +436,8 @@ def train(
                 mode="val",
             )
 
+        v_history[-1] /= len(vals)
+
         logging.info(
             "Validation : Epoch: [%d/%d] | Loss: %f | Recon: %f | "
             "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
@@ -460,8 +462,6 @@ def train(
             plot_all = stopper.early_stop(v_history, t_history)
         else:
             plot_all = False
-
-        v_history[-1] /= len(vals)
 
         if writer:
             for i, loss_name in enumerate(

--- a/avae/train.py
+++ b/avae/train.py
@@ -661,7 +661,7 @@ def train(
                 os.mkdir("states")
 
             filename = (
-                +str(timestamp)
+                str(timestamp)
                 + "_E"
                 + str(epoch)
                 + "_"

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -283,24 +283,24 @@ class EarlyStopping:
             val_train_kl = [v[2] for v in train_loss][-self.patience :]
             val_train_affinity = [v[3] for v in train_loss][-self.patience :]
 
-            if self.trigger == "total_loss":
+            if self.trigger == "total_loss" or self.trigger == "all":
 
                 if self.__evaluate_loss(total_val_loss, total_train_loss):
                     logging.info('Early stopping triggered on "total_loss"')
                     self.stop = True
 
-            elif self.trigger == "reco_loss" or self.trigger == "all":
+            if self.trigger == "reco_loss" or self.trigger == "all":
 
                 if self.__evaluate_loss(val_loss_reco, val_train_reco):
                     logging.info('Early stopping triggered on "reco_loss"')
                     self.stop = True
 
-            elif self.trigger == "kldiv_loss" or self.trigger == "all":
+            if self.trigger == "kldiv_loss" or self.trigger == "all":
                 if self.__evaluate_loss(val_loss_kl, val_train_kl):
                     logging.info('Early stopping triggered on "kldiv_loss"')
                     self.stop = True
 
-            elif self.trigger == "affinity_loss" or self.trigger == "all":
+            if self.trigger == "affinity_loss" or self.trigger == "all":
                 if self.__evaluate_loss(val_loss_affinity, val_train_affinity):
                     logging.info('Early stopping triggered on "affinity_loss"')
                     self.stop = True

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -211,7 +211,7 @@ def add_meta(
     return meta_df
 
 
-def early_stopping(val_loss, patience, condition="total_loss"):
+def early_stopping(val_loss, patience, trigger="all"):
     """
     Early stopping function. Returns true if validation loss doesn't improve after a given patience.
     Depending on the condition, evaluation of loss improuvement can be done on
@@ -223,10 +223,10 @@ def early_stopping(val_loss, patience, condition="total_loss"):
         List of validation losses.
     patience: int
         Number of previous epochs to use on the evaluation of loss improvement.
-    condition: str
+    trigger: str
         Condition to evaluate loss improvement. Can be "total_loss", "reco_loss", "kldiv_loss" or "affinity_loss" or "all".
     """
-    if condition not in [
+    if trigger not in [
         "total_loss",
         "reco_loss",
         "kldiv_loss",
@@ -234,30 +234,30 @@ def early_stopping(val_loss, patience, condition="total_loss"):
         "all",
     ]:
         raise ValueError(
-            "condition must be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'"
+            "early stopping trigger must be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'"
         )
 
     stop = False
     if patience < len(val_loss):
 
-        total_val_loss = [v[0] for v in val_loss][-patience:-1]
-        val_loss_reco = [v[1] for v in val_loss][-patience:-1]
-        val_loss_kl = [v[2] for v in val_loss][-patience:-1]
-        val_loss_affinity = [v[3] for v in val_loss][-patience:-1]
+        total_val_loss = [v[0] for v in val_loss][-patience:]
+        val_loss_reco = [v[1] for v in val_loss][-patience:]
+        val_loss_kl = [v[2] for v in val_loss][-patience:]
+        val_loss_affinity = [v[3] for v in val_loss][-patience:]
 
         if total_val_loss.index(min(total_val_loss)) == 0 and (
-            condition == "total_loss" or condition == "all"
+            trigger == "total_loss" or trigger == "all"
         ):
             stop = True
-        elif (condition == "reco_loss" or condition == "all") and (
+        elif (trigger == "reco_loss" or trigger == "all") and (
             val_loss_reco.index(min(val_loss_reco)) == 0
         ):
             stop = True
-        elif (condition == "kldiv_loss" or condition == "all") and (
+        elif (trigger == "kldiv_loss" or trigger == "all") and (
             val_loss_kl.index(min(val_loss_kl)) == 0
         ):
             stop = True
-        elif (condition == "affinity_loss" or condition == "all") and (
+        elif (trigger == "affinity_loss" or trigger == "all") and (
             val_loss_affinity.index(min(val_loss_affinity)) == 0
         ):
             stop = True

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -211,7 +211,7 @@ def add_meta(
     return meta_df
 
 
-def early_stopping(val_loss, patience, trigger="all"):
+def early_stopping_trigger(val_loss, patience, trigger="all"):
     """
     Early stopping function. Returns true if validation loss doesn't improve after a given patience.
     Depending on the condition, evaluation of loss improuvement can be done on

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -271,20 +271,17 @@ class EarlyStopping:
             List of validation losses.
         """
 
-        if (
-            self.patience < len(val_loss[0])
-            and len(val_loss[0]) > self.min_epochs
-        ):
+        if self.patience < len(val_loss) and len(val_loss) > self.min_epochs:
 
-            total_val_loss = [v for v in val_loss[0]][-self.patience :]
-            val_loss_reco = [v for v in val_loss[1]][-self.patience :]
-            val_loss_kl = [v for v in val_loss[2]][-self.patience :]
-            val_loss_affinity = [v for v in val_loss[3]][-self.patience :]
+            total_val_loss = [v[0] for v in val_loss][-self.patience :]
+            val_loss_reco = [v[1] for v in val_loss][-self.patience :]
+            val_loss_kl = [v[2] for v in val_loss][-self.patience :]
+            val_loss_affinity = [v[3] for v in val_loss][-self.patience :]
 
-            total_train_loss = [v for v in train_loss[0]][-self.patience :]
-            val_train_reco = [v for v in train_loss[1]][-self.patience :]
-            val_train_kl = [v for v in train_loss[2]][-self.patience :]
-            val_train_affinity = [v for v in train_loss[3]][-self.patience :]
+            total_train_loss = [v[0] for v in train_loss][-self.patience :]
+            val_train_reco = [v[1] for v in train_loss][-self.patience :]
+            val_train_kl = [v[2] for v in train_loss][-self.patience :]
+            val_train_affinity = [v[3] for v in train_loss][-self.patience :]
 
             if self.trigger == "total_loss":
 

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -211,19 +211,55 @@ def add_meta(
     return meta_df
 
 
-def early_stopping(val_loss, patience):
+def early_stopping(val_loss, patience, condition="total_loss"):
     """
-    Returns true if validation loss doesn't improve after a given patience.
+    Early stopping function. Returns true if validation loss doesn't improve after a given patience.
+    Depending on the condition, evaluation of loss improuvement can be done on
+    the total loss, reconstruction loss, KL divergence or affinity loss.
 
+    Parameters
+    ----------
+    val_loss: list
+        List of validation losses.
+    patience: int
+        Number of previous epochs to use on the evaluation of loss improvement.
+    condition: str
+        Condition to evaluate loss improvement. Can be "total_loss", "reco_loss", "kldiv_loss" or "affinity_loss" or "all".
     """
+    if condition not in [
+        "total_loss",
+        "reco_loss",
+        "kldiv_loss",
+        "affinity_loss",
+        "all",
+    ]:
+        raise ValueError(
+            "condition must be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'"
+        )
 
-    early_stopping = False
+    stop = False
     if patience < len(val_loss):
 
-        loss_history = val_loss[-patience:-1]
+        total_val_loss = [v[0] for v in val_loss][-patience:-1]
+        val_loss_reco = [v[1] for v in val_loss][-patience:-1]
+        val_loss_kl = [v[2] for v in val_loss][-patience:-1]
+        val_loss_affinity = [v[3] for v in val_loss][-patience:-1]
 
-        if loss_history.index(min(loss_history)) == 0:
+        if total_val_loss.index(min(total_val_loss)) == 0 and (
+            condition == "total_loss" or condition == "all"
+        ):
+            stop = True
+        elif (condition == "reco_loss" or condition == "all") and (
+            val_loss_reco.index(min(val_loss_reco)) == 0
+        ):
+            stop = True
+        elif (condition == "kldiv_loss" or condition == "all") and (
+            val_loss_kl.index(min(val_loss_kl)) == 0
+        ):
+            stop = True
+        elif (condition == "affinity_loss" or condition == "all") and (
+            val_loss_affinity.index(min(val_loss_affinity)) == 0
+        ):
+            stop = True
 
-            early_stopping = True
-
-    return early_stopping
+    return stop

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -224,9 +224,9 @@ class EarlyStopping:
     patience: int
         Number of previous epochs to use on the evaluation of loss improvement.
     max_delta: float
-        Minimum change in loss to be considered as an improvement.
+        Minimum change in loss to be considered as an improvement (ratio).
     max_divergence: float
-        Max change in validation loss with respect to the trainin loss.
+        Max change in validation loss with respect to the trainin loss (ratio).
     min_epochs: int
         Minimum number of epochs to run before early stopping can be triggered.
 

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -255,6 +255,7 @@ class EarlyStopping:
         self.max_delta = max_delta
         self.max_divergence = max_divergence
         self.min_epochs = min_epochs
+        self.stop = False
 
     def early_stop(self, val_loss, train_loss):
         """
@@ -270,7 +271,6 @@ class EarlyStopping:
             List of validation losses.
         """
 
-        stop = False
         if self.patience < len(val_loss) and len(val_loss) > self.min_epochs:
 
             total_val_loss = [v[0] for v in val_loss][-self.patience :]
@@ -287,25 +287,25 @@ class EarlyStopping:
 
                 if self.__evaluate_loss(total_val_loss, total_train_loss):
                     logging.info('Early stopping triggered on "total_loss"')
-                    stop = True
+                    self.stop = True
 
             elif self.trigger == "reco_loss" or self.trigger == "all":
 
                 if self.__evaluate_loss(val_loss_reco, val_train_reco):
                     logging.info('Early stopping triggered on "reco_loss"')
-                    stop = True
+                    self.stop = True
 
             elif self.trigger == "kldiv_loss" or self.trigger == "all":
                 if self.__evaluate_loss(val_loss_kl, val_train_kl):
                     logging.info('Early stopping triggered on "kldiv_loss"')
-                    stop = True
+                    self.stop = True
 
             elif self.trigger == "affinity_loss" or self.trigger == "all":
                 if self.__evaluate_loss(val_loss_affinity, val_train_affinity):
                     logging.info('Early stopping triggered on "affinity_loss"')
-                    stop = True
+                    self.stop = True
 
-        return stop
+        return self.stop
 
     def __evaluate_loss(self, valid_loss, train_loss):
 

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -246,20 +246,24 @@ def early_stopping_trigger(val_loss, patience, trigger="all"):
         val_loss_affinity = [v[3] for v in val_loss][-patience:]
 
         if total_val_loss.index(min(total_val_loss)) == 0 and (
-            trigger == "total_loss" or trigger == "all"
+            trigger == "total_loss"
         ):
+            logging.info('Early stopping triggered on "total_loss"')
             stop = True
         elif (trigger == "reco_loss" or trigger == "all") and (
             val_loss_reco.index(min(val_loss_reco)) == 0
         ):
+            logging.info('Early stopping triggered on "reco_loss"')
             stop = True
         elif (trigger == "kldiv_loss" or trigger == "all") and (
             val_loss_kl.index(min(val_loss_kl)) == 0
         ):
+            logging.info('Early stopping triggered on "kldiv_loss"')
             stop = True
         elif (trigger == "affinity_loss" or trigger == "all") and (
             val_loss_affinity.index(min(val_loss_affinity)) == 0
         ):
+            logging.info('Early stopping triggered on "affinity_loss"')
             stop = True
 
     return stop

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -209,3 +209,21 @@ def add_meta(
         [meta_df, meta], ignore_index=False
     )  # ignore index doesn't overwrite
     return meta_df
+
+
+def early_stopping(val_loss, patience):
+    """
+    Returns true if validation loss doesn't improve after a given patience.
+
+    """
+
+    early_stopping = False
+    if patience < len(val_loss):
+
+        loss_history = val_loss[-patience:-1]
+
+        if loss_history.index(min(loss_history)) == 0:
+
+            early_stopping = True
+
+    return early_stopping

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -271,17 +271,20 @@ class EarlyStopping:
             List of validation losses.
         """
 
-        if self.patience < len(val_loss) and len(val_loss) > self.min_epochs:
+        if (
+            self.patience < len(val_loss[0])
+            and len(val_loss[0]) > self.min_epochs
+        ):
 
-            total_val_loss = [v[0] for v in val_loss][-self.patience :]
-            val_loss_reco = [v[1] for v in val_loss][-self.patience :]
-            val_loss_kl = [v[2] for v in val_loss][-self.patience :]
-            val_loss_affinity = [v[3] for v in val_loss][-self.patience :]
+            total_val_loss = [v for v in val_loss[0]][-self.patience :]
+            val_loss_reco = [v for v in val_loss[1]][-self.patience :]
+            val_loss_kl = [v for v in val_loss[2]][-self.patience :]
+            val_loss_affinity = [v for v in val_loss[3]][-self.patience :]
 
-            total_train_loss = [v[0] for v in train_loss][-self.patience :]
-            val_train_reco = [v[1] for v in train_loss][-self.patience :]
-            val_train_kl = [v[2] for v in train_loss][-self.patience :]
-            val_train_affinity = [v[3] for v in train_loss][-self.patience :]
+            total_train_loss = [v for v in train_loss[0]][-self.patience :]
+            val_train_reco = [v for v in train_loss[1]][-self.patience :]
+            val_train_kl = [v for v in train_loss[2]][-self.patience :]
+            val_train_affinity = [v for v in train_loss[3]][-self.patience :]
 
             if self.trigger == "total_loss":
 
@@ -320,12 +323,14 @@ class EarlyStopping:
             valid_loss
         ):
             logging.info(
-                "Early stopping triggered: validation loss is not improving"
+                "Early stopping triggered: validation loss is not improving. Fluctuation is within {:.2f}% of minimum validation loss.".format(
+                    (max(valid_loss) - min(valid_loss)) / min(valid_loss) * 100
+                )
             )
             stop = True
 
         diff_loses = (np.array(valid_loss) - np.array(train_loss)).tolist()
-        if diff_loses.index(min(diff_loses)) == 0 and valid_loss.max() > max(
+        if diff_loses.index(min(diff_loses)) == 0 and max(valid_loss) > max(
             train_loss
         ) + self.max_divergence * max(train_loss):
             logging.info(

--- a/run.py
+++ b/run.py
@@ -520,6 +520,20 @@ logging.basicConfig(
     default=None,
     help="Condition to trigger early stopping based on loss improvement. Can be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'.",
 )
+@click.option(
+    "--es_patience",
+    "-espatience",
+    type=str,
+    default=None,
+    help="Number of previous epochs to use on the evaluation of loss improvement.",
+)
+@click.option(
+    "--minimum_train",
+    "-mintrain",
+    type=float,
+    default=None,
+    help="Minimum fraction of the training to run before evaluation for early stopping.",
+)
 def run(
     config_file,
     datapath,
@@ -590,6 +604,8 @@ def run(
     debug,
     early_stopping,
     es_trigger,
+    es_patience,
+    minimum_train,
 ):
 
     warnings.simplefilter("ignore", FutureWarning)
@@ -657,6 +673,9 @@ def run(
         config.FREQ_ACC = data["freq_acc"]
         config.FREQ_STA = data["freq_sta"]
         config.FREQ_SIM = data["freq_sim"]
+
+    if data["minimum_train"] is not None:
+        config.MIN_TRAIN = data["minimum_train"]
 
     if data["new_out"]:
         dir_name = f'results_{dt_name}_lat{data["latent_dims"]}_pose{data["pose_dims"]}_lr{data["learning"]}_beta{data["beta"]}_gamma{data["gamma"]}'
@@ -731,6 +750,7 @@ def run_pipeline(data):
             classifier=data["classifier"],
             early_stopping=data["early_stopping"],
             es_loss_trigger=data["es_trigger"],
+            es_patience=data["es_patience"],
         )
     else:
         evaluate(

--- a/run.py
+++ b/run.py
@@ -523,7 +523,7 @@ logging.basicConfig(
 @click.option(
     "--es_patience",
     "-espatience",
-    type=str,
+    type=int,
     default=None,
     help="Number of previous epochs to use on the evaluation of loss improvement.",
 )

--- a/run.py
+++ b/run.py
@@ -505,6 +505,21 @@ logging.basicConfig(
     is_flag=True,
     help="Log metrics and figures to tensorboard during training",
 )
+@click.option(
+    "--early_stopping",
+    "-es",
+    type=bool,
+    default=None,
+    is_flag=True,
+    help="Early stop the training if the validation loss does not improve for a given number of epochs (10).",
+)
+@click.option(
+    "--es_trigger",
+    "-estrig",
+    type=str,
+    default=None,
+    help="Condition to trigger early stopping based on loss improvement. Can be 'total_loss', 'reco_loss', 'kldiv_loss', 'affinity_loss' or 'all'.",
+)
 def run(
     config_file,
     datapath,
@@ -573,6 +588,8 @@ def run(
     classifier,
     new_out,
     debug,
+    early_stopping,
+    es_trigger,
 ):
 
     warnings.simplefilter("ignore", FutureWarning)
@@ -712,6 +729,8 @@ def run_pipeline(data):
             rescale=data["rescale"],
             tensorboard=data["tensorboard"],
             classifier=data["classifier"],
+            early_stopping=data["early_stopping"],
+            es_trigger=data["es_trigger"],
         )
     else:
         evaluate(

--- a/run.py
+++ b/run.py
@@ -730,7 +730,7 @@ def run_pipeline(data):
             tensorboard=data["tensorboard"],
             classifier=data["classifier"],
             early_stopping=data["early_stopping"],
-            es_trigger=data["es_trigger"],
+            es_loss_trigger=data["es_trigger"],
         )
     else:
         evaluate(

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -1,0 +1,192 @@
+import random
+import unittest
+
+import numpy as np
+
+from avae.utils_learning import EarlyStopping
+
+# fixing random seeds so we dont get fail on mrc tests
+random.seed(10)
+
+
+class EarlyStopTest(unittest.TestCase):
+    def setUp(self) -> None:
+
+        self.stopper_total = EarlyStopping(
+            loss_type="total_loss",
+            patience=10,
+            max_delta=0.01,
+            max_divergence=0.2,
+            min_epochs=20,
+        )
+        self.stopper_kld = EarlyStopping(
+            loss_type="kldiv_loss",
+            patience=10,
+            max_delta=0.01,
+            max_divergence=0.2,
+            min_epochs=20,
+        )
+        self.stopper_affinity = EarlyStopping(
+            loss_type="affinity_loss",
+            patience=10,
+            max_delta=0.1,
+            max_divergence=0.2,
+            min_epochs=20,
+        )
+        self.stopper_reco = EarlyStopping(
+            loss_type="reco_loss",
+            patience=10,
+            max_delta=0.01,
+            max_divergence=0.2,
+            min_epochs=20,
+        )
+
+        recon_loss_train = np.linspace(10, 0.001, 100)
+        kldivergence_train = np.linspace(0.1, 0.001, 100)
+        affin_loss_train = np.linspace(0.1, 0.001, 100)
+        # total loss
+        total_loss_train = (
+            recon_loss_train + kldivergence_train + affin_loss_train
+        )
+
+        self.loss_train = [
+            total_loss_train,
+            recon_loss_train,
+            kldivergence_train,
+            affin_loss_train,
+        ]
+
+        self.recon_loss_val = np.linspace(10, 0.001, 100)
+        self.kldivergence_val = np.linspace(1, 0.1, 100)
+
+        self.affin_loss_val = np.linspace(0.1, 0.001, 100)
+
+        # total loss
+        self.total_loss_val = (
+            self.recon_loss_val + self.kldivergence_val + self.affin_loss_val
+        )
+
+        self.loss_val = [
+            self.total_loss_val,
+            self.recon_loss_val,
+            self.kldivergence_val,
+            self.affin_loss_val,
+        ]
+
+    def test_early_stopping_decreasing_loss(self):
+
+        stop_total = self.stopper_total.early_stop(
+            self.loss_val, self.loss_train
+        )
+        stop_recon = self.stopper_reco.early_stop(
+            self.loss_val, self.loss_train
+        )
+        stop_kldiv = self.stopper_kld.early_stop(
+            self.loss_val, self.loss_train
+        )
+        stop_affinity = self.stopper_affinity.early_stop(
+            self.loss_val, self.loss_train
+        )
+
+        assert stop_total is False
+        assert stop_recon is False
+        assert stop_kldiv is False
+        assert stop_affinity is False
+
+    def test_early_stopping_increasing_single_loss(self):
+
+        kldivergence_val = np.linspace(0.001, 0.1, 100)
+
+        affin_loss_val = np.linspace(0.1, 0.01, 100)
+
+        # total loss
+        total_loss_val = (
+            self.recon_loss_val + kldivergence_val + affin_loss_val
+        )
+
+        loss_val = [
+            total_loss_val,
+            self.recon_loss_val,
+            kldivergence_val,
+            affin_loss_val,
+        ]
+
+        stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
+        stop_kldiv = self.stopper_kld.early_stop(loss_val, self.loss_train)
+        stop_affinity = self.stopper_affinity.early_stop(
+            loss_val, self.loss_train
+        )
+
+        assert stop_total is False
+        assert stop_kldiv is True
+        assert stop_affinity is True
+
+    def test_early_stopping_increasing_total_loss(self):
+
+        kldivergence_val = np.linspace(0.1, 10, 100)
+
+        # total loss
+        total_loss_val = (
+            self.recon_loss_val + kldivergence_val + self.affin_loss_val
+        )
+
+        loss_val = [
+            total_loss_val,
+            self.recon_loss_val,
+            kldivergence_val,
+            self.affin_loss_val,
+        ]
+
+        stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
+        stop_kldiv = self.stopper_kld.early_stop(loss_val, self.loss_train)
+
+        assert stop_total is True
+        assert stop_kldiv is True
+
+    def test_early_stopping_fluctuating_loss(self):
+
+        recon_loss_val = np.random.uniform(1, 1.1, 100)
+
+        # total loss
+        total_loss_val = (
+            recon_loss_val + self.kldivergence_val + self.affin_loss_val
+        )
+
+        loss_val = [
+            total_loss_val,
+            recon_loss_val,
+            self.kldivergence_val,
+            self.affin_loss_val,
+        ]
+
+        stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
+        stop_recon = self.stopper_reco.early_stop(loss_val, self.loss_train)
+
+        assert stop_total is True
+        assert stop_recon is True
+
+    def test_early_stopping_decreasing_loss_within_tolerance(self):
+
+        recon_loss_val = np.random.uniform(1, 1.005, 100)
+
+        affin_loss_val = np.linspace(0.1, 0.0009, 100)
+
+        # total loss
+        total_loss_val = (
+            recon_loss_val + self.kldivergence_val + affin_loss_val
+        )
+
+        loss_val = [
+            total_loss_val,
+            recon_loss_val,
+            self.kldivergence_val,
+            affin_loss_val,
+        ]
+
+        stop_recon = self.stopper_reco.early_stop(loss_val, self.loss_train)
+        stop_affinity = self.stopper_affinity.early_stop(
+            loss_val, self.loss_train
+        )
+
+        assert stop_affinity is False
+        assert stop_recon is False

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -41,19 +41,24 @@ class EarlyStopTest(unittest.TestCase):
             min_epochs=20,
         )
 
-        recon_loss_train = np.linspace(10, 0.001, 100)
-        kldivergence_train = np.linspace(0.1, 0.001, 100)
-        affin_loss_train = np.linspace(0.1, 0.001, 100)
+        self.recon_loss_train = np.linspace(10, 0.001, 100)
+        self.kldivergence_train = np.linspace(0.1, 0.001, 100)
+        self.affin_loss_train = np.linspace(0.1, 0.001, 100)
         # total loss
-        total_loss_train = (
-            recon_loss_train + kldivergence_train + affin_loss_train
+        self.total_loss_train = (
+            self.recon_loss_train
+            + self.kldivergence_train
+            + self.affin_loss_train
         )
 
         self.loss_train = [
-            total_loss_train,
-            recon_loss_train,
-            kldivergence_train,
-            affin_loss_train,
+            [
+                self.total_loss_train[i],
+                self.recon_loss_train[i],
+                self.kldivergence_train[i],
+                self.affin_loss_train[i],
+            ]
+            for i in range(len(self.total_loss_train))
         ]
 
         self.recon_loss_val = np.linspace(10, 0.001, 100)
@@ -67,10 +72,13 @@ class EarlyStopTest(unittest.TestCase):
         )
 
         self.loss_val = [
-            self.total_loss_val,
-            self.recon_loss_val,
-            self.kldivergence_val,
-            self.affin_loss_val,
+            [
+                self.total_loss_val[i],
+                self.recon_loss_val[i],
+                self.kldivergence_val[i],
+                self.affin_loss_val[i],
+            ]
+            for i in range(len(self.total_loss_val))
         ]
 
     def test_early_stopping_decreasing_loss(self):
@@ -105,10 +113,13 @@ class EarlyStopTest(unittest.TestCase):
         )
 
         loss_val = [
-            total_loss_val,
-            self.recon_loss_val,
-            kldivergence_val,
-            affin_loss_val,
+            [
+                total_loss_val[i],
+                self.recon_loss_val[i],
+                kldivergence_val[i],
+                affin_loss_val[i],
+            ]
+            for i in range(len(total_loss_val))
         ]
 
         stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
@@ -131,10 +142,13 @@ class EarlyStopTest(unittest.TestCase):
         )
 
         loss_val = [
-            total_loss_val,
-            self.recon_loss_val,
-            kldivergence_val,
-            self.affin_loss_val,
+            [
+                total_loss_val[i],
+                self.recon_loss_val[i],
+                kldivergence_val[i],
+                self.affin_loss_val[i],
+            ]
+            for i in range(len(total_loss_val))
         ]
 
         stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
@@ -153,10 +167,13 @@ class EarlyStopTest(unittest.TestCase):
         )
 
         loss_val = [
-            total_loss_val,
-            recon_loss_val,
-            self.kldivergence_val,
-            self.affin_loss_val,
+            [
+                total_loss_val[i],
+                recon_loss_val[i],
+                self.kldivergence_val[i],
+                self.affin_loss_val[i],
+            ]
+            for i in range(len(total_loss_val))
         ]
 
         stop_total = self.stopper_total.early_stop(loss_val, self.loss_train)
@@ -177,10 +194,13 @@ class EarlyStopTest(unittest.TestCase):
         )
 
         loss_val = [
-            total_loss_val,
-            self.recon_loss_val,
-            kldivergence_val,
-            affin_loss_val,
+            [
+                total_loss_val[i],
+                self.recon_loss_val[i],
+                kldivergence_val[i],
+                affin_loss_val[i],
+            ]
+            for i in range(len(total_loss_val))
         ]
 
         stop_recon = self.stopper_reco.early_stop(loss_val, self.loss_train)

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -145,7 +145,7 @@ class EarlyStopTest(unittest.TestCase):
 
     def test_early_stopping_fluctuating_loss(self):
 
-        recon_loss_val = np.random.uniform(1, 1.1, 100)
+        recon_loss_val = np.random.uniform(1, 1.01, 100)
 
         # total loss
         total_loss_val = (
@@ -167,19 +167,19 @@ class EarlyStopTest(unittest.TestCase):
 
     def test_early_stopping_decreasing_loss_within_tolerance(self):
 
-        recon_loss_val = np.random.uniform(1, 1.005, 100)
+        kldivergence_val = np.random.uniform(1, 1.1, 100)
 
         affin_loss_val = np.linspace(0.1, 0.0009, 100)
 
         # total loss
         total_loss_val = (
-            recon_loss_val + self.kldivergence_val + affin_loss_val
+            self.recon_loss_val + kldivergence_val + affin_loss_val
         )
 
         loss_val = [
             total_loss_val,
-            recon_loss_val,
-            self.kldivergence_val,
+            self.recon_loss_val,
+            kldivergence_val,
             affin_loss_val,
         ]
 

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -66,6 +66,8 @@ class TrainEvalTest(unittest.TestCase):
             "classifier": "NN",
             "new_out": False,
             "opt_method": "adam",
+            "early_stopping": False,
+            "es_trigger": "all",
         }
 
         config.FREQ_ACC = 5

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -68,6 +68,7 @@ class TrainEvalTest(unittest.TestCase):
             "opt_method": "adam",
             "early_stopping": False,
             "es_trigger": "all",
+            "es_patience": 10,
         }
 
         config.FREQ_ACC = 5
@@ -92,6 +93,8 @@ class TrainEvalTest(unittest.TestCase):
         config.VIS_AFF = True
         config.VIS_SIM = True
         config.VIS_DYN = True
+
+        config.MIN_TRAIN = 3
 
     def test_model_a_mrc(self):
         self.data["model"] = "a"

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -68,7 +68,7 @@ class TrainEvalTest(unittest.TestCase):
             "opt_method": "adam",
             "early_stopping": False,
             "es_trigger": "all",
-            "es_patience": 10,
+            "es_patience": 5,
         }
 
         config.FREQ_ACC = 5


### PR DESCRIPTION
Fixes #25

- [x] If validation loss doesn't decrease in N number of epochs, early stopping training flag is true. This can be triggered by 'total_loss', 'reco_loss', 'affinity_loss' and 'kldiv_loss' or 'all' (configurable on input)
- [x] If early stopping trigger is true make all plots, save model and meta file.
- [x] If early stopping config flag and the internal flag is True, stop training, otherwise save checkpoints and continue training.
Todos:
- [x] Check that this is only evaluated when beta and gamma are on the nominal values in case of cyclical scheduling. 
    - [x] Make sure loss within patience is not within scheduling either
- [x] Add early stopping when loss is fluctuating within 1% of the value
- [x] Add early stopping when loss is diverging from training loss.
- [x] Only save early stopping state once, if training is ongoing. 
- [x] Add tests for different scenarios

Other minor changes:

- [x] On training only log at epoch level, instead of batch level
- [x] Addresses part of #220