### PR TITLE
Update loss to use long indices

### DIFF
--- a/avae/loss.py
+++ b/avae/loss.py
@@ -50,9 +50,11 @@ class AffinityLoss:
         loss : torch.Tensor
             The affinity loss.
         """
-        # first calculate the affinity ,for the real classes
-        c = torch.combinations(y_true, r=2, with_replacement=False).to(
-            self.device
+        # first calculate the affinity, for the real classes
+        c = (
+            torch.combinations(y_true, r=2, with_replacement=False)
+            .to(self.device)
+            .long()
         )
         affinity = self.lookup[c[:, 0], c[:, 1]].to(self.device)
 


### PR DESCRIPTION
When running the tests on my local machine, I encountered an error:

```
IndexError tensors used as indices must be long, byte or bool tensors
```
This PR provides a small fix to use long indexing when calculating the affinity loss.