### PR TITLE
Fix per-class pose visualisation and associated tests

### DIFF
--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -177,7 +177,7 @@ def evaluate(
         vis.pose_disentanglement_plot(
             x_test, p_test, vae, data_dim, device, mode="_eval"
         )
-        vis.pose_interpolation_plot(
+        vis.pose_class_disentanglement_plot(
             x_test,
             y_test,
             config.VIS_POSE_CLASS,

--- a/avae/train.py
+++ b/avae/train.py
@@ -602,7 +602,7 @@ def train(
                 x_train, p_train, vae, data_dim, device
             )
 
-            vis.pose_interpolation_plot(
+            vis.pose_class_disentanglement_plot(
                 x_train,
                 y_train,
                 config.VIS_POSE_CLASS,

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -1136,14 +1136,23 @@ def latent_disentamglement_plot(
         save_imshow_png(f"disentanglement-latent_{mode}.png", grid_for_napari)
 
 
-def pose_interpolation_plot(
+def pose_class_disentanglement_plot(
     x, y, pose_vis_class, poses, vae, data_dim, device, mode="trn"
 ):
-
+    pose_vis_class = pose_vis_class.replace(" ", "").split(",")
     for i in pose_vis_class:
-        class_reps_x = np.take(x, [np.where(np.array(y) == i)[0][0]], axis=0)
+        class_reps_x = np.take(x, np.where(np.array(y) == i)[0], axis=0)
+        class_reps_poses = np.take(
+            poses, np.where(np.array(y) == i)[0], axis=0
+        )
         pose_disentanglement_plot(
-            class_reps_x, poses, vae, data_dim, device, label=i, mode="trn"
+            class_reps_x,
+            class_reps_poses,
+            vae,
+            data_dim,
+            device,
+            label=i,
+            mode="trn",
         )
 
 
@@ -1166,7 +1175,12 @@ def pose_disentanglement_plot(
     logging.info(
         "################################################################",
     )
-    logging.info("Visualising pose disentanglement ...\n")
+    if label == "avg":
+        logging.info("Visualising pose disentanglement ...\n")
+    else:
+        logging.info(
+            "Visualising pose disentanglement for class {}...\n".format(label)
+        )
 
     number_of_samples = 7
     padding = 0

--- a/run.py
+++ b/run.py
@@ -582,9 +582,6 @@ def run(
     local_vars = locals().copy()
     data = load_config_params(config_file, local_vars)
 
-    if data["vis_pose_class"]:
-        data["vis_pose_class"] = data["vis_pose_class"].split(",")
-
     if data["debug"]:
         logging.info("Debug mode enabled")
         logging.getLogger().setLevel(logging.DEBUG)

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -93,7 +93,7 @@ class TrainEvalTest(unittest.TestCase):
 
     def test_model_a_mrc(self):
         self.data["model"] = "a"
-        config.VIS_POSE_VIS = ["1b23", "1dkg"]
+        config.VIS_POSE_CLASS = "1b23,1dkg"
 
         (
             n_dir_train,
@@ -106,17 +106,17 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 30)
+        self.assertEqual(n_plots_train, 32)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
 
-        self.assertEqual(n_plots_eval, 48)
+        self.assertEqual(n_plots_eval, 50)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
     def test_model_b_mrc(self):
         self.data["model"] = "b"
-        config.VIS_POSE_VIS = ["1b23", "1dkg"]
+        config.VIS_POSE_CLASS = "1b23,1dkg"
 
         (
             n_dir_train,
@@ -129,10 +129,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 30)
+        self.assertEqual(n_plots_train, 32)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 48)
+        self.assertEqual(n_plots_eval, 50)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -140,7 +140,7 @@ class TrainEvalTest(unittest.TestCase):
         self.data["model"] = "a"
         self.data["datatype"] = "npy"
         self.data["datapath"] = self.testdata_npy
-        config.VIS_POSE_VIS = ["2", "5"]
+        config.VIS_POSE_CLASS = "2,5"
 
         self.data["affinity"] = os.path.join(
             self.testdata_npy, "affinity_an.csv"
@@ -157,10 +157,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 28)
+        self.assertEqual(n_plots_train, 30)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 45)
+        self.assertEqual(n_plots_eval, 47)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 


### PR DESCRIPTION
The testing for this never ran as it was triggered using a variable with a typo.

The per-class pose visualisation itself was missing trimming the pose set to class representatitves.

Fixes #228