### PR TITLE
Add pose space visualisation

### DIFF
--- a/avae/train.py
+++ b/avae/train.py
@@ -572,6 +572,8 @@ def train(
                     y_val,
                     np.full(shape=len(x_test), fill_value="test"),
                 ]
+                if pose:
+                    ps = np.r_[p_train, p_val, p_test]
             else:
                 xs = np.r_[x_train, x_val]
                 ys = np.r_[y_train, y_val]

--- a/avae/train.py
+++ b/avae/train.py
@@ -575,12 +575,20 @@ def train(
             else:
                 xs = np.r_[x_train, x_val]
                 ys = np.r_[y_train, y_val]
-            vis.latent_embed_plot_tsne(
-                xs, ys, classes_list, epoch=epoch, writer=writer
-            )
+                if pose:
+                    ps = np.r_[p_train, p_val]
+
+            vis.latent_embed_plot_tsne(xs, ys, epoch=epoch, writer=writer)
             vis.latent_embed_plot_umap(
                 xs, ys, classes_list, epoch=epoch, writer=writer
             )
+            if pose:
+                vis.latent_embed_plot_tsne(
+                    ps, ys, epoch=epoch, writer=writer, mode="pose"
+                )
+                vis.latent_embed_plot_umap(
+                    ps, ys, epoch=epoch, writer=writer, mode="pose"
+                )
 
             if config.VIS_DYN:
                 # merge img and rec into one image for display in altair

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -306,6 +306,9 @@ def latent_embed_plot_umap(
     else:
         logging.info("Visualising static UMAP embedding " + mode + "...\n")
 
+    xs = np.asarray(xs)
+    ys = np.asarray(ys)
+
     if len(xs.shape) != 2:
         logging.error("Embedding only accepts 2D arrays.")
         exit(1)

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -259,7 +259,16 @@ def latent_embed_plot_tsne(
                 histtype="step",
                 stacked=True,
                 fill=False,
+                label=mol[:4],
             )
+        plt.legend(
+            prop={"size": 10},
+            bbox_to_anchor=(1.05, 1),
+            loc="upper left",
+            fontsize=16,
+        )
+        plt.xlabel("dim 1")
+        plt.ylabel("freq")
 
     plt.tight_layout()
     plt.savefig(f"plots/embedding_TSNE{mode}.png")
@@ -368,7 +377,16 @@ def latent_embed_plot_umap(
                 histtype="step",
                 stacked=True,
                 fill=False,
+                label=mol[:4],
             )
+        plt.legend(
+            prop={"size": 10},
+            bbox_to_anchor=(1.05, 1),
+            loc="upper left",
+            fontsize=16,
+        )
+        plt.xlabel("dim 1")
+        plt.ylabel("freq")
 
     plt.tight_layout()
     plt.savefig(f"plots/embedding_UMAP{mode}.png")

--- a/avae/vis.py
+++ b/avae/vis.py
@@ -171,7 +171,10 @@ def latent_embed_plot_tsne(
     logging.info(
         "################################################################",
     )
-    logging.info("Visualising static TSNE embedding...\n")
+    if not mode:
+        logging.info("Visualising static TSNE embedding...\n")
+    else:
+        logging.info("Visualising static TSNE embedding " + mode + "...\n")
 
     xs = np.asarray(xs)
     ys = np.asarray(ys)
@@ -180,9 +183,27 @@ def latent_embed_plot_tsne(
     if len(ys) < perplexity:
         perplexity = len(ys) - 1
 
-    lats = TSNE(
-        n_components=2, perplexity=perplexity, random_state=42
-    ).fit_transform(xs)
+    if len(xs.shape) != 2:
+        logging.error("Embedding only accepts 2D arrays.")
+        exit(1)
+    if xs.shape[-1] == 1:
+        logging.warning(
+            "Data contains 1 dimension, cannot create embedding,"
+            " plotting histogram instead...\n"
+        )
+    if xs.shape[-1] == 2:
+        logging.warning(
+            "Data already contains 2 dimensions, cannot create"
+            " embedding, plotting scatter of original data...\n"
+        )
+
+    if xs.shape[-1] > 2:
+        lats = TSNE(
+            n_components=2, perplexity=perplexity, random_state=42
+        ).fit_transform(xs)
+    elif xs.shape[-1] == 2 or xs.shape[-1] == 1:
+        lats = xs
+
     if classes is None:
         classes = sorted(list(np.unique(ys)))
     else:
@@ -203,27 +224,43 @@ def latent_embed_plot_tsne(
             figsize=(int(n_classes / 2) + 4, int(n_classes / 2) + 2)
         )
     # When the number of classes is less than 3 the image becomes two small
-
     colours = colour_per_class(classes)
 
-    for mol_id, mol in enumerate(set(ys.tolist())):
-        idx = np.where(np.array(ys.tolist()) == mol)[0]
+    if xs.shape[-1] != 1:
 
-        color = colours[classes.index(mol)]
+        for mol_id, mol in enumerate(set(ys.tolist())):
+            idx = np.where(np.array(ys.tolist()) == mol)[0]
 
-        plt.scatter(
-            lats[idx, 0],
-            lats[idx, 1],
-            s=24,
-            label=mol[:4],
-            facecolor=color,
-            edgecolor=color,
-            alpha=0.2,
-        )
+            color = colours[classes.index(mol)]
 
-    ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize=16)
-    plt.xlabel("TSNE-1")
-    plt.ylabel("TSNE-2")
+            plt.scatter(
+                lats[idx, 0],
+                lats[idx, 1],
+                s=24,
+                label=mol[:4],
+                facecolor=color,
+                edgecolor=color,
+                alpha=0.2,
+            )
+
+        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize=16)
+        plt.xlabel("TSNE-1")
+        plt.ylabel("TSNE-2")
+
+    if xs.shape[-1] == 1:
+
+        for mol_id, mol in enumerate(set(ys.tolist())):
+            idx = np.where(np.array(ys.tolist()) == mol)[0]
+            cols = colours[classes.index(mol)]
+            plt.hist(
+                lats[idx],
+                100,
+                color=cols,
+                histtype="step",
+                stacked=True,
+                fill=False,
+            )
+
     plt.tight_layout()
     plt.savefig(f"plots/embedding_TSNE{mode}.png")
 
@@ -255,9 +292,30 @@ def latent_embed_plot_umap(
         "################################################################",
     )
 
-    logging.info("Visualising static UMAP embedding...\n")
-    reducer = umap.UMAP(random_state=42)
-    embedding = reducer.fit_transform(xs)
+    if not mode:
+        logging.info("Visualising static UMAP embedding...\n")
+    else:
+        logging.info("Visualising static UMAP embedding " + mode + "...\n")
+
+    if len(xs.shape) != 2:
+        logging.error("Embedding only accepts 2D arrays.")
+        exit(1)
+    if xs.shape[-1] == 1:
+        logging.warning(
+            "Data contains 1 dimension, cannot create embedding,"
+            " plotting histogram instead...\n"
+        )
+    if xs.shape[-1] == 2:
+        logging.warning(
+            "Data already contains 2 dimensions, cannot create"
+            " embedding, plotting scatter of original data...\n"
+        )
+
+    if xs.shape[-1] > 2:
+        reducer = umap.UMAP(random_state=42)
+        embedding = reducer.fit_transform(xs)
+    elif xs.shape[-1] == 2 or xs.shape[-1] == 1:
+        embedding = xs
 
     if classes is None:
         classes = sorted(list(np.unique(ys)))
@@ -278,23 +336,40 @@ def latent_embed_plot_umap(
 
     colours = colour_per_class(classes)
 
-    for mol_id, mol in enumerate(set(ys.tolist())):
-        idx = np.where(np.array(ys.tolist()) == mol)[0]
-        color = colours[classes.index(mol)]
+    if xs.shape[-1] != 1:
 
-        ax.scatter(
-            embedding[idx, 0],
-            embedding[idx, 1],
-            s=24,
-            label=mol[:4],
-            facecolor=color,
-            edgecolor=color,
-            alpha=0.2,
-        )
+        for mol_id, mol in enumerate(set(ys.tolist())):
+            idx = np.where(np.array(ys.tolist()) == mol)[0]
+            color = colours[classes.index(mol)]
 
-    ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize=16)
-    plt.xlabel("UMAP-1")
-    plt.ylabel("UMAP-2")
+            ax.scatter(
+                embedding[idx, 0],
+                embedding[idx, 1],
+                s=24,
+                label=mol[:4],
+                facecolor=color,
+                edgecolor=color,
+                alpha=0.2,
+            )
+
+        ax.legend(bbox_to_anchor=(1.05, 1), loc="upper left", fontsize=16)
+        plt.xlabel("UMAP-1")
+        plt.ylabel("UMAP-2")
+
+    if xs.shape[-1] == 1:
+
+        for mol_id, mol in enumerate(set(ys.tolist())):
+            idx = np.where(np.array(ys.tolist()) == mol)[0]
+            cols = colours[classes.index(mol)]
+            plt.hist(
+                embedding[idx],
+                100,
+                color=cols,
+                histtype="step",
+                stacked=True,
+                fill=False,
+            )
+
     plt.tight_layout()
     plt.savefig(f"plots/embedding_UMAP{mode}.png")
 

--- a/tests/test_train_eval_pipeline.py
+++ b/tests/test_train_eval_pipeline.py
@@ -106,11 +106,11 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 32)
+        self.assertEqual(n_plots_train, 34)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
 
-        self.assertEqual(n_plots_eval, 50)
+        self.assertEqual(n_plots_eval, 52)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -129,10 +129,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 32)
+        self.assertEqual(n_plots_train, 34)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 50)
+        self.assertEqual(n_plots_eval, 52)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -157,10 +157,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 30)
+        self.assertEqual(n_plots_train, 32)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 47)
+        self.assertEqual(n_plots_eval, 49)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 
@@ -185,10 +185,10 @@ class TrainEvalTest(unittest.TestCase):
         ) = helper_train_eval(self.data)
 
         self.assertEqual(n_dir_train, 4)
-        self.assertEqual(n_plots_train, 30)
+        self.assertEqual(n_plots_train, 32)
         self.assertEqual(n_latent_train, 2)
         self.assertEqual(n_states_train, 2)
-        self.assertEqual(n_plots_eval, 47)
+        self.assertEqual(n_plots_eval, 49)
         self.assertEqual(n_latent_eval, 4)
         self.assertEqual(n_states_eval, 3)
 


### PR DESCRIPTION
Either as embedding if it's >2 dimensions, or direct plot if it's 2D, or overlapping (for each class) non-filled histogram if it's 1D. Class colors should be corresponding between 1D and 2D plots.

Example plot 1D:
![Screenshot from 2023-10-27 18-26-00](https://github.com/alan-turing-institute/affinity-vae/assets/6930946/f733459a-4753-4b4d-a63f-37ea70207f4a)

Example plot 2D (executing same code as latent embedding so should follow the formatting exactly):
![Screenshot from 2023-10-27 11-50-09](https://github.com/alan-turing-institute/affinity-vae/assets/6930946/8205f5d5-0730-4f65-972a-d5bb4ba57299)
