### PR TITLE
Reduce logging

### DIFF
--- a/avae/train.py
+++ b/avae/train.py
@@ -365,21 +365,20 @@ def train(
                 mode="trn",
             )
 
-            logging.info(
-                "Training : Epoch: [%d/%d] | Batch: [%d/%d] | Loss: %f | Recon: %f | "
-                "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
-                % (
-                    epoch + 1,
-                    epochs,
-                    b + 1,
-                    len(trains),
-                    *t_history[-1],
-                    beta_arr[epoch],
-                    gamma_arr[epoch],
-                )
-            )
-
         t_history[-1] /= len(trains)
+
+        logging.info(
+            "Training : Epoch: [%d/%d] | Loss: %f | Recon: %f | "
+            "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
+            % (
+                epoch + 1,
+                epochs,
+                len(trains),
+                *t_history[-1],
+                beta_arr[epoch],
+                gamma_arr[epoch],
+            )
+        )
 
         # ########################## VAL ######################################
         vae.eval()
@@ -420,22 +419,20 @@ def train(
                 v_logvar,
                 mode="val",
             )
-
-            logging.info(
-                "Validation : Epoch: [%d/%d] | Batch: [%d/%d] | Loss: %f | Recon: %f | "
-                "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
-                % (
-                    epoch + 1,
-                    epochs,
-                    b + 1,
-                    len(vals),
-                    *v_history[-1],
-                    beta_arr[epoch],
-                    gamma_arr[epoch],
-                )
-            )
-
         v_history[-1] /= len(vals)
+
+        logging.info(
+            "Validation : Epoch: [%d/%d] |Loss: %f | Recon: %f | "
+            "KLdiv: %f | Affin: %f | Beta: %f | Gamma: %f"
+            % (
+                epoch + 1,
+                epochs,
+                len(vals),
+                *v_history[-1],
+                beta_arr[epoch],
+                gamma_arr[epoch],
+            )
+        )
 
         if writer:
             for i, loss_name in enumerate(

--- a/avae/train.py
+++ b/avae/train.py
@@ -373,7 +373,6 @@ def train(
             % (
                 epoch + 1,
                 epochs,
-                len(trains),
                 *t_history[-1],
                 beta_arr[epoch],
                 gamma_arr[epoch],
@@ -427,7 +426,6 @@ def train(
             % (
                 epoch + 1,
                 epochs,
-                len(vals),
                 *v_history[-1],
                 beta_arr[epoch],
                 gamma_arr[epoch],


### PR DESCRIPTION
Reduce logging to epoch level to accelerate run. 

If we want to log at batch level, we can use the debug flag. 