### PR TITLE
Flexible installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,49 +59,18 @@ python -m pytest -s -W ignore
 The following is the recommended way of installing all libraries in Baskervile.
 
 ```
-conda create --name affinity_env
-conda activate affinity_env
+module load bask-apps/live
+module load PyTorch/2.0.1-foss-2022a-CUDA-11.7.0
+module load torchvision/0.15.2-foss-2022a-CUDA-11.7.0
 
-conda install --yes python=3.10
-conda install --yes numpy
-conda install --yes requests
-conda install --yes -c anaconda pandas
-conda install --yes -c anaconda scikit-image
-conda install --yes -c anaconda scikit-learn
-conda install --yes -c anaconda scipy
-conda install --yes -c anaconda pillow
-conda install --yes -c conda-forge mrcfile
-conda install --yes -c conda-forge altair
-conda install --yes -c conda-forge umap-learn
-conda install --yes -c conda-forge matplotlib
-conda install --yes -c anaconda click
-conda install pytorch torchvision  pytorch-cuda=11.8 -c pytorch -c nvidia
-pip install pyyaml
-pip install pydantic
+python -m venv pyenv_affinity
+source pyenv_affinity/bin/activate
+
+git clone https://github.com/alan-turing-institute/affinity-vae.git
+cd  affinity-vae/
+python -m pip install -e ."[baskerville]"
 ```
 
-**Note**
-
-If you have shortage of space, it is always a good idea to run
-`conda clean --all` before you proceed from here as pytorch packages require
-space to download
-
-Regarding installation of pytorch, please follow the latest pytorch installation
-recommendation provided online as using older versions can cause conflict
-between packages that conda would not be able to resolve easily. The current
-version requires a cuda=11.8
-
-if the follwoing error occurs:
-
-```
-:ImportError: libtiff.so.5: cannot open shared object file: No such file or directory
-```
-
-you can resolve it via:
-
-```
-conda install -c anaconda libtiff==4.4.0
-```
 
 ### Quick start
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ with the following:
 python -m venv env
 source env/bin/activate
 python -m pip install --upgrade pip
-python -m pip install -e .
+python -m pip install -e ."[all]"
 ```
 
 If you are developing code, you should be able to run pre-commits and tests,
@@ -50,7 +50,7 @@ python -m pytest -s -W ignore
 > Warning: M1 macOS can not do
 > [pytorch paralelisation](https://github.com/pytorch/pytorch/issues/70344). A
 > temporary solution for this is to modify the code on the DataLoaders in
-> data.py to `num_workers=0` in order to run the code. Otherwise you will get
+> data.py to `num_workers=0` in order to run the code. Otherwise, you will get
 > the error:
 > `AttributeError: Can't pickle local object 'ProteinDataset.__init__.<locals>.<lambda>'`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,27 +20,23 @@ classifiers = [
     "Operating System :: MacOS",
 ]
 requires-python = ">=3.10"
-[common-dependencies]
-altair = "*"
-click = "*"
-mrcfile = "*"
-matplotlib = "*"
-numpy = "*"
-scipy = "*"
-pillow = "*"
-pandas = "*"
-pyyaml = "*"
-requests = "*"
-scikit-image = "*"
-scikit-learn = "*"
-tensorboard = "*"
-umap-learn = "*"
 
-[training-dependencies]
-torch = "*"
-torchvision = "*"
-pydantic = ">2"
-
+dependencies = [
+    "altair",
+    "click",
+    "mrcfile",
+    "matplotlib",
+    "numpy",
+    "scipy",
+    "pillow",
+    "pandas",
+    "pyyaml",
+    "requests",
+    "scikit-image",
+    "scikit-learn",
+    "tensorboard",
+    "umap-learn",
+]
 
 [project.readme]
 file = "README.md"
@@ -56,37 +52,28 @@ envs.default.dependencies = [
   "pytest-cov",
 ]
 
-[project.dependencies]
-all = [
-    { include = "common-dependencies" },
-    { include = "training-dependencies" }
-]
 
 
 [project.optional-dependencies]
+all = ["torch",
+    "torchvision",
+    "pydantic>2"]
+
 test = [
+    "affinivae[all]",
     "pytest >=6",
     "pytest-cov >=3",
-    { include = "training-dependencies" },
-    { include = "common-dependencies" }
-
 ]
 
+baskerville = [
+    "pydantic>2"
+]
 napari = [
     "napari[all]",
     "torch",
     "torchvision",
     "pydantic<2", # latest napari version is incompatible with napari, napari demo doesnt use pydantic.
-    { include = "common-dependencies" }
-
 ]
-
-[project.extras]
-baskerville = [
-    { include = "common-dependencies" },
-    "pydantic>2"
-]
-
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,6 @@ license = {text = "BSD 3-Clause"}
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
@@ -21,26 +19,28 @@ classifiers = [
     "Operating System :: Unix",
     "Operating System :: MacOS",
 ]
-requires-python = ">=3.8"
-dependencies = [
-    "altair",
-    "click",
-    "mrcfile",
-    "matplotlib",
-    "numpy",
-    "scipy",
-    "pillow",
-    "pandas",
-    "pyyaml",
-    "requests",
-    "scikit-image",
-    "scikit-learn",
-    "tensorboard",
-    "torch",
-    "torchvision",
-    "umap-learn",
-    "pydantic"
-]
+requires-python = ">=3.10"
+[common-dependencies]
+altair = "*"
+click = "*"
+mrcfile = "*"
+matplotlib = "*"
+numpy = "*"
+scipy = "*"
+pillow = "*"
+pandas = "*"
+pyyaml = "*"
+requests = "*"
+scikit-image = "*"
+scikit-learn = "*"
+tensorboard = "*"
+umap-learn = "*"
+
+[training-dependencies]
+torch = "*"
+torchvision = "*"
+pydantic = ">2"
+
 
 [project.readme]
 file = "README.md"
@@ -56,21 +56,38 @@ envs.default.dependencies = [
   "pytest-cov",
 ]
 
+[project.dependencies]
+all = [
+    { include = "common-dependencies" },
+    { include = "training-dependencies" }
+]
+
+
 [project.optional-dependencies]
 test = [
     "pytest >=6",
     "pytest-cov >=3",
-    "pre-commit",
+    { include = "training-dependencies" },
+    { include = "common-dependencies" }
+
 ]
-dev = [
-    "pytest >=6",
-    "pytest-cov >=3",
-    "pre-commit",
-]
+
 napari = [
     "napari[all]",
+    "torch",
+    "torchvision",
     "pydantic<2", # latest napari version is incompatible with napari, napari demo doesnt use pydantic.
+    { include = "common-dependencies" }
+
 ]
+
+[project.extras]
+baskerville = [
+    { include = "common-dependencies" },
+    "pydantic>2"
+]
+
+
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = ["-ra", "--showlocals"]#, "--strict-markers", "--strict-config"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,9 +17,9 @@ python -m pip install --upgrade pip
 python -m pip install -e ."[napari]"
 ```
 
-> **Important note**: This environment should only be used for running the
-> Napari plugin. If you want to run the AffinityVAE model, you'll need to
-> install the requirements in a different python environment. The reason for
+> **Important note**: This installation should only be used for running the
+> Napari plugin. If you want to train/run the AffinityVAE model, you'll need to
+> reinstall the package using the "all" option (e.g ```python -m pip install -e ."[all]"```). The reason for
 > this is that the napari library requires an older version of pydantic (1.10.0)
 > and the AffinityVAE model requires pydantic > 2.0 or higher.
 
@@ -63,10 +63,10 @@ Using the `umap` option can be slow, as the manifold is created on the fly and
 reversed everytime you click on a point on the embedding map. If you want to use
 the precomputed manifold from the AffinityVAE run, you can use the `load` option
 (adding the flag `--manifold "load"` to the command line. This will use the
-embedding variables from the meta file to create the manifold and it will
+embedding variables from the meta file to create the manifold, and it will
 reverse to the latent space by finding the closest distance point in the data.
 This is much faster than using the `umap` option and a good option for quick
-debugging/exploring. However this option will not allow you explore unseen
+debugging/exploring. However, this option will not allow you to explore unseen
 regions of the latent space, only the available data.
 
 **Example of usage**

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -11,7 +11,7 @@ pip:
 python -m venv env
 source env/bin/activate
 python -m pip install --upgrade pip
-python -m pip install -e .
+python -m pip install -e ."[all]"
 ```
 
 ### 2. Download the MNIST dataset


### PR DESCRIPTION
Fixes #271

> Installation is different depending on what are we trying to do:
>
> - For baskerville we can't use the usual `python -m pip install .` as torch and tochvision need to be loaded independently.
> - Locally and in tests we need a full installation equivalent to `python -m pip install .`
> - Napari plugin conflicts with full installation because requirements for pydantic are different.
>
>Solution:
>
> 1. `python -m pip install .` should have a minimal installation needed for everything, but it doesn't have all dependencies.
> 2. `python -m pip install ."[baskerville]"` will have the needed libraries for running in baskervile (which need to be > complemented with torch and tochvision modules).
> 3. `python -m pip install ."[all]"` should have everything to train the model locally.
> 4. `python -m pip install ."[napari]"` with have the base version of dependencies from 1. plus the version of pydantic that > is compatible with napari. 
> 3. `python -m pip install ."[tests]"` should have everything to train the model locally, run tests and commit changes.
