### PR TITLE
Training refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ you can send a SLURM job to the cluster using the script in [tools](tools/slurm_
 sbatch slurm_run.sh
 ```
 
-### Quick start
+
+## Running Affinity-VAE: A quick start
 
 We have a [tutorial](tutorials/README.md) on how to run Affinity-VAE on the
 MNIST dataset. We recommend to start there for the first time you run
 Affinity-VAE.
+
+<details>
+<summary><i>Affinity-VAE configuration parameters</i></summary>
 
 Affinity-VAE has a running script (`run.py`) that allows you to configure and
 run the code. You can look at the available configuration options by running:
@@ -128,9 +132,22 @@ Options:
   -de, --depth INTEGER            Depth of the convolutional layers (default
                                   3).
   -ch, --channels INTEGER         First layer channels (default 64).
+  -fl, --filters TEXT             Comma-separated list of filters for the
+                                  network. Either provide filters, or capacity
+                                  and depth.
   -ld, --latent_dims INTEGER      Latent space dimension (default 10).
   -pd, --pose_dims INTEGER        If pose on, number of pose dimensions. If 0
                                   and gamma=0 it becomesa standard beta-VAE.
+  -bn_enc, --bnorm_encoder        Batch normalisation in encoder is on if
+                                  True.
+  -bn_dec, --bnorm_decoder        Batch normalisation in encoder is on if
+                                  True.
+  -gsdcl, --gsd_conv_layers INTEGER
+                                  The number of output channels for the
+                                  convolution layers at the end of the GSD
+                                  decoder
+  -spl, --n_splats INTEGER        Number of Gaussian splats.
+  -kr, --klreduction TEXT         Mean or sum reduction on KLD term.
   -be, --beta FLOAT               Beta maximum in the case of cyclical
                                   annealing schedule
   -bl, --beta_load                The path to the saved beta array file to be
@@ -165,7 +182,8 @@ Options:
   -ev, --eval                     Evaluate test data.
   -dn, --dynamic                  Enable collecting meta and dynamic latent
                                   space plots.
-  -m, --model TEXT                Choose model to run.
+  -m, --model TEXT                Choose model to run. The choice of models
+                                  are a, b, u and gsd
   -vl, --vis_los                  Visualise loss (every epoch starting at
                                   epoch 2).
   -vac, --vis_acc                 Visualise confusion matrix and F1 scores
@@ -181,13 +199,16 @@ Options:
   -vps, --vis_pos                 Visualise pose disentanglement (frequency
                                   controlled).
   -vpsc, --vis_pose_class TEXT    Example: A,B,C. your deliminator should be
-                                  commas and no spaces .Classes to be used for
+                                  commas and no spaces. Classes to be used for
                                   pose interpolation (a seperate pose
                                   interpolation figure would be created for
                                   each class).
-  -vpsc, --vis_z_n_int TEXT       Number of Latent interpolation classes to to be printed, number of interpolation steps in each  plot.
-                                  Example: 1,10. 1 plot with 10 interpolation steps between two classes.
-                                  your deliminator should be commas and no spaces.
+  -vzni, --vis_z_n_int TEXT       Number of Latent interpolation classes to to
+                                  be printed, number of interpolation steps in
+                                  each  plot. Example: 1,10. 1 plot with 10
+                                  interpolation steps between two classes.
+                                  your deliminator should be commas and no
+                                  spaces.
   -vc, --vis_cyc                  Visualise cyclical parameters (once per
                                   run).
   -va, --vis_aff                  Visualise affinity matrix (once per run).
@@ -195,7 +216,8 @@ Options:
                                   per run).
   -similarity, --vis_sim          Visualise train-val model similarity matrix.
   -va, --vis_all                  Visualise all above.
-  -vf, --vis_format               The format of saved images. Options: png , pdf
+  -vf, --vis_format TEXT          The format of saved images. Options: png ,
+                                  pdf
   -fev, --freq_eval INTEGER       Frequency at which to evaluate test set.
   -fs, --freq_sta INTEGER         Frequency at which to save state
   -fac, --freq_acc INTEGER        Frequency at which to visualise confusion
@@ -222,17 +244,20 @@ Options:
   -nrm, --normalise               Normalise data
   -sftm, --shift_min              Shift the minimum of the data to one zero
                                   and the maximum to one
-  -res --rescale                  Rescale images to given value (tuple, one
+  -res, --rescale INTEGER         Rescale images to given value (tuple, one
                                   value per dim).
   -tb, --tensorboard              Log metrics and figures to tensorboard
                                   during training
+  -st, --strategy TEXT            Define the strategy for distributed
+                                  training. Options are: 'ddp', 'deepspeed' or
+                                  'fsdp
   --help                          Show this message and exit.
 ```
 
 Note that setting `-g/--gamma` to `0` and `-pd/--pose_dims` to `0` will run a
 vanilla beta-VAE.
+</details>
 
-### Quickstart
 
 #### Configuring from the command line
 

--- a/avae/base.py
+++ b/avae/base.py
@@ -1,4 +1,5 @@
 import enum
+import logging
 
 import torch
 
@@ -34,3 +35,35 @@ class AbstractAffinityVAE(torch.nn.Module):
         raise NotImplementedError(
             "Reparameterize method must be implemented in child class."
         )
+
+
+def set_layer_dim(
+    ndim: SpatialDims | int,
+) -> tuple[torch.nn.Module, torch.nn.Module, torch.nn.Module]:
+    if ndim == SpatialDims.TWO:
+        return torch.nn.Conv2d, torch.nn.ConvTranspose2d, torch.nn.BatchNorm2d
+    elif ndim == SpatialDims.THREE:
+        return torch.nn.Conv3d, torch.nn.ConvTranspose3d, torch.nn.BatchNorm3d
+    else:
+        logging.error("Data must be 2D or 3D.")
+        exit(1)
+
+
+def dims_after_pooling(start: int, n_pools: int) -> int:
+    """Calculate the size of a layer after n pooling ops.
+
+    Parameters
+    ----------
+    start: int
+        The size of the layer before pooling.
+    n_pools: int
+        The number of pooling operations.
+
+    Returns
+    -------
+    int
+        The size of the layer after pooling.
+
+
+    """
+    return start // (2**n_pools)

--- a/avae/decoders/decoders.py
+++ b/avae/decoders/decoders.py
@@ -4,8 +4,8 @@ import logging
 import numpy as np
 import torch
 
+from avae.base import dims_after_pooling, set_layer_dim
 from avae.decoders.base import AbstractDecoder
-from avae.models import dims_after_pooling, set_layer_dim
 
 
 class Decoder(AbstractDecoder):

--- a/avae/decoders/decoders.py
+++ b/avae/decoders/decoders.py
@@ -13,7 +13,7 @@ class Decoder(AbstractDecoder):
 
     Parameters
     ----------
-    input_size: tuple (X, Y) or tuple (X, Y, Z)
+    input_shape: tuple (X, Y) or tuple (X, Y, Z)
         Tuple representing the size of the data for each image
         dimension X, Y and Z.
     latent_dims: int
@@ -33,7 +33,7 @@ class Decoder(AbstractDecoder):
 
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: int | None = None,
         filters: list[int] | None = None,
         depth: int = 4,
@@ -76,7 +76,7 @@ class Decoder(AbstractDecoder):
             assert all(
                 [
                     int(x) == x
-                    for x in np.array(input_size) / (2 ** len(self.filters))
+                    for x in np.array(input_shape) / (2 ** len(self.filters))
                 ]
             ), (
                 "Input size not compatible with --depth. Input must be divisible "
@@ -84,14 +84,14 @@ class Decoder(AbstractDecoder):
             )
 
             self.bottom_dim = tuple(
-                [int(i / (2 ** len(self.filters))) for i in input_size]
+                [int(i / (2 ** len(self.filters))) for i in input_shape]
             )
 
             # define layer dimensions
-            CONV, TCONV, BNORM = set_layer_dim(len(input_size))
+            CONV, TCONV, BNORM = set_layer_dim(len(input_shape))
 
         else:
-            self.bottom_dim = input_size
+            self.bottom_dim = input_shape
 
         if latent_dims <= 0:
             raise RuntimeError(

--- a/avae/decoders/decoders.py
+++ b/avae/decoders/decoders.py
@@ -177,7 +177,7 @@ class Decoder(AbstractDecoder):
 class DecoderA(AbstractDecoder):
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: int = 8,
         depth: int = 4,
         latent_dims: int = 8,
@@ -189,7 +189,7 @@ class DecoderA(AbstractDecoder):
         self.bnorm = bnorm
 
         assert all(
-            [int(x) == x for x in np.array(input_size) / (2**depth)]
+            [int(x) == x for x in np.array(input_shape) / (2**depth)]
         ), (
             "Input size not compatible with --depth. Input must be divisible "
             "by {}.".format(2**depth)
@@ -200,7 +200,7 @@ class DecoderA(AbstractDecoder):
             [
                 filters[-1],
             ]
-            + [dims_after_pooling(ax, depth) for ax in input_size]
+            + [dims_after_pooling(ax, depth) for ax in input_shape]
         )
         flat_shape = np.prod(unflat_shape)
 
@@ -276,7 +276,7 @@ class DecoderB(AbstractDecoder):
 
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: int,
         depth: int = 4,
         latent_dims: int = 8,
@@ -288,13 +288,13 @@ class DecoderB(AbstractDecoder):
         self.pose = not (pose_dims == 0)
 
         assert all(
-            [int(x) == x for x in np.array(input_size) / (2**depth)]
+            [int(x) == x for x in np.array(input_shape) / (2**depth)]
         ), (
             "Input size not compatible with --depth. Input must be divisible "
             "by {}.".format(2**depth)
         )
-        _, TCONV, BNORM = set_layer_dim(len(input_size))
-        self.bottom_dim = tuple([int(i / (2**depth)) for i in input_size])
+        _, TCONV, BNORM = set_layer_dim(len(input_shape))
+        self.bottom_dim = tuple([int(i / (2**depth)) for i in input_shape])
 
         #  iteratively define deconvolution and batch normalisation layers
         self.conv_dec = torch.nn.ModuleList()

--- a/avae/encoders/encoders.py
+++ b/avae/encoders/encoders.py
@@ -13,7 +13,7 @@ class Encoder(AbstractEncoder):
 
     Parameters
     ----------
-    input_size: tuple (X, Y) or tuple (X, Y, Z)
+    input_shape: tuple (X, Y) or tuple (X, Y, Z)
         Tuple representing the size of the data for each image
         dimension X, Y and Z.
     latent_dims: int
@@ -33,7 +33,7 @@ class Encoder(AbstractEncoder):
 
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: int | None = None,
         filters: list[int] | None = None,
         depth: int = 4,
@@ -77,7 +77,7 @@ class Encoder(AbstractEncoder):
             assert all(
                 [
                     int(x) == x
-                    for x in np.array(input_size) / (2 ** len(self.filters))
+                    for x in np.array(input_shape) / (2 ** len(self.filters))
                 ]
             ), (
                 "Input size not compatible with --depth. Input must be divisible "
@@ -85,14 +85,14 @@ class Encoder(AbstractEncoder):
             )
 
             bottom_dim = tuple(
-                [int(i / (2 ** len(self.filters))) for i in input_size]
+                [int(i / (2 ** len(self.filters))) for i in input_shape]
             )
 
             # define layer dimensions
-            CONV, TCONV, BNORM = set_layer_dim(len(input_size))
+            CONV, TCONV, BNORM = set_layer_dim(len(input_shape))
 
         else:
-            bottom_dim = input_size
+            bottom_dim = input_shape
 
         if latent_dims <= 0:
             raise RuntimeError(
@@ -271,7 +271,7 @@ class EncoderB(AbstractEncoder):
 
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: int = 8,
         depth: int = 4,
         latent_dims: int = 8,
@@ -280,13 +280,13 @@ class EncoderB(AbstractEncoder):
         super(EncoderB, self).__init__()
 
         assert all(
-            [int(x) == x for x in np.array(input_size) / (2**depth)]
+            [int(x) == x for x in np.array(input_shape) / (2**depth)]
         ), (
             "Input size not compatible with --depth. Input must be divisible "
             "by {}.".format(2**depth)
         )
-        CONV, _, BNORM = set_layer_dim(len(input_size))
-        self.bottom_dim = tuple([int(i / (2**depth)) for i in input_size])
+        CONV, _, BNORM = set_layer_dim(len(input_shape))
+        self.bottom_dim = tuple([int(i / (2**depth)) for i in input_shape])
 
         self.depth = depth
         self.pose = not (pose_dims == 0)

--- a/avae/encoders/encoders.py
+++ b/avae/encoders/encoders.py
@@ -188,7 +188,7 @@ class Encoder(AbstractEncoder):
 class EncoderA(AbstractEncoder):
     def __init__(
         self,
-        input_size: tuple,
+        input_shape: tuple,
         capacity: Optional[int] = None,
         depth: int = 4,
         latent_dims: int = 8,
@@ -200,7 +200,7 @@ class EncoderA(AbstractEncoder):
         self.bnorm = bnorm
 
         assert all(
-            [int(x) == x for x in np.array(input_size) / (2**depth)]
+            [int(x) == x for x in np.array(input_shape) / (2**depth)]
         ), (
             "Input size not compatible with --depth. Input must be divisible "
             "by {}.".format(2**depth)
@@ -211,7 +211,7 @@ class EncoderA(AbstractEncoder):
             [
                 filters[-1],
             ]
-            + [dims_after_pooling(ax, depth) for ax in input_size]
+            + [dims_after_pooling(ax, depth) for ax in input_shape]
         )
         flat_shape = np.prod(unflat_shape)
 

--- a/avae/encoders/encoders.py
+++ b/avae/encoders/encoders.py
@@ -4,8 +4,8 @@ from typing import Optional
 import numpy as np
 import torch
 
+from avae.base import dims_after_pooling, set_layer_dim
 from avae.encoders.base import AbstractEncoder
-from avae.models import dims_after_pooling, set_layer_dim
 
 
 class Encoder(AbstractEncoder):

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -9,7 +9,7 @@ import torch
 from . import settings, vis
 from .data import load_data
 from .utils import accuracy, latest_file
-from .utils_learning import add_meta, pass_batch, set_device
+from .utils_learning import add_meta
 
 
 def evaluate(
@@ -122,7 +122,7 @@ def evaluate(
     logging.debug("Batch: [0/%d]" % (len(tests)))
 
     vae.eval()
-    for b, (t, label, aff, meta_data) in enumerate(tests):
+    for batch_number, (t, label, aff, meta_data) in enumerate(tests):
 
         # get data in the right device
         t, aff = t.to(device), aff.to(device)
@@ -152,8 +152,8 @@ def evaluate(
             mode="evl",
         )
 
-        logging.debug("Batch: [%d/%d]" % (b + 1, len(tests)))
-    logging.info("Batch: [%d/%d]" % (b + 1, len(tests)))
+        logging.debug("Batch: [%d/%d]" % (batch_number + 1, len(tests)))
+    logging.info("Batch: [%d/%d]" % (batch_number + 1, len(tests)))
 
     # ########################## VISUALISE ################################
     if classes is not None:

--- a/avae/evaluate.py
+++ b/avae/evaluate.py
@@ -113,9 +113,7 @@ def evaluate(
     meta_df = pd.read_pickle(meta)
 
     # create holders for latent spaces and labels
-    x_test = []
-    y_test = []
-    c_test = []
+    x_test, y_test, c_test = [], [], []
     p_test = None
 
     if pose_dims != 0:
@@ -124,29 +122,33 @@ def evaluate(
     logging.debug("Batch: [0/%d]" % (len(tests)))
 
     vae.eval()
-    for b, batch in enumerate(tests):
-        x, x_hat, lat_mu, lat_logvar, lat, lat_pose, _ = pass_batch(
-            fabric=fabric, vae=vae, batch=batch, b=b, batches=len(tests)
-        )
-        x_test.extend(lat_mu.cpu().detach().numpy())
-        c_test.extend(lat_logvar.cpu().detach().numpy())
+    for b, (t, label, aff, meta_data) in enumerate(tests):
 
+        # get data in the right device
+        t, aff = t.to(device), aff.to(device)
+        t = t.to(torch.float32)
+
+        # forward
+        t_hat, t_mu, t_logvar, tlat, tlat_pose = vae(t)
+
+        x_test.extend(t_mu.cpu().detach().numpy())  # store latents
+        c_test.extend(t_logvar.cpu().detach().numpy())
         # if labels are present save them otherwise save test
         try:
-            y_test.extend(batch[1])
+            y_test.extend(label)
         except IndexError:
-            np.full(shape=len(batch[0]), fill_value="test")
-        if lat_pose is not None:
-            p_test.extend(lat_pose.cpu().detach().numpy())
+            np.full(shape=len(t), fill_value="test")
+        if tlat_pose is not None:
+            p_test.extend(tlat_pose.cpu().detach().numpy())
 
         meta_df = add_meta(
             data_dim,
             meta_df,
-            batch[-1],
-            x_hat,
-            lat_mu,
-            lat_pose,
-            lat_logvar,
+            meta_data,
+            t_hat,
+            t_mu,
+            tlat_pose,
+            tlat,
             mode="evl",
         )
 
@@ -160,7 +162,7 @@ def evaluate(
         classes_list = []
     # visualise reconstructions - last batch
     if settings.VIS_REC:
-        vis.recon_plot(x, x_hat, y_test, data_dim, mode="evl")
+        vis.recon_plot(t, t_hat, y_test, data_dim, mode="evl")
 
     # visualise latent disentanglement
     if settings.VIS_DIS:

--- a/avae/models.py
+++ b/avae/models.py
@@ -69,18 +69,18 @@ def set_device(gpu: bool) -> torch.device:
 
 
 def build_model(
-    model_type,
-    input_size,
-    channels,
-    depth,
-    lat_dims,
-    pose_dims,
-    bnorm_encoder,
-    bnorm_decoder,
-    n_splats,
-    gsd_conv_layers,
-    device,
-    filters=None,
+    model_type: str,
+    input_shape: tuple,
+    channels: int,
+    depth: int,
+    lat_dims: int,
+    pose_dims: int,
+    bnorm_encoder: bool,
+    bnorm_decoder: bool,
+    n_splats: int,
+    gsd_conv_layers: int,
+    device: torch.device,
+    filters: list | None = None,
 ):
     """Create the AffinityVAE model.
 
@@ -88,7 +88,7 @@ def build_model(
     ----------
     model_type : str
         The type of model to create. Must be one of : a, b, u or gsd.
-    input_size : int
+    input_shape : tuple
         The size of the input.
     channels : int
         The number of channels in the model.
@@ -108,7 +108,7 @@ def build_model(
         The number of convolutional layers in the Gaussian Splat Decoder.
     device : torch.device
         The device to use for training and inference.
-    filters : list
+    filters : list or None
         The filters to use in the model.
 
     """
@@ -120,7 +120,7 @@ def build_model(
 
     if model_type == "a":
         encoder = EncoderA(
-            input_size,
+            input_shape,
             channels,
             depth,
             lat_dims,
@@ -128,7 +128,7 @@ def build_model(
             bnorm=bnorm_encoder,
         )
         decoder = DecoderA(
-            input_size,
+            input_shape,
             channels,
             depth,
             lat_dims,
@@ -136,11 +136,11 @@ def build_model(
             bnorm=bnorm_decoder,
         )
     elif model_type == "b":
-        encoder = EncoderB(input_size, channels, depth, lat_dims, pose_dims)
-        decoder = DecoderB(input_size, channels, depth, lat_dims, pose_dims)
+        encoder = EncoderB(input_shape, channels, depth, lat_dims, pose_dims)
+        decoder = DecoderB(input_shape, channels, depth, lat_dims, pose_dims)
     elif model_type == "u":
         encoder = Encoder(
-            input_size=input_size,
+            input_size=input_shape,
             capacity=channels,
             filters=filters,
             depth=depth,
@@ -149,7 +149,7 @@ def build_model(
             bnorm=bnorm_encoder,
         )
         decoder = Decoder(
-            input_size=input_size,
+            input_shape=input_shape,
             capacity=channels,
             filters=filters,
             depth=depth,
@@ -159,7 +159,7 @@ def build_model(
         )
     elif model_type == "gsd":
         encoder = EncoderA(
-            input_size,
+            input_shape,
             channels,
             depth,
             lat_dims,
@@ -167,7 +167,7 @@ def build_model(
             bnorm=bnorm_encoder,
         )
         decoder = GaussianSplatDecoder(
-            input_size,
+            input_shape,
             n_splats=n_splats,
             latent_dims=lat_dims,
             output_channels=gsd_conv_layers,

--- a/avae/models.py
+++ b/avae/models.py
@@ -1,10 +1,14 @@
 import logging
 from abc import ABC, abstractmethod
 
+import numpy as np
 import torch
 import torch.nn as nn
 
 from avae.base import AbstractAffinityVAE
+from avae.decoders.decoders import Decoder, DecoderA, DecoderB
+from avae.decoders.differentiable import GaussianSplatDecoder
+from avae.encoders.encoders import Encoder, EncoderA, EncoderB
 
 from .base import SpatialDims
 
@@ -62,6 +66,124 @@ def set_device(gpu: bool) -> torch.device:
             "\n\nWARNING: no GPU available, running on CPU instead.\n"
         )
     return device
+
+
+def build_model(
+    model_type,
+    input_size,
+    channels,
+    depth,
+    lat_dims,
+    pose_dims,
+    bnorm_encoder,
+    bnorm_decoder,
+    n_splats,
+    gsd_conv_layers,
+    device,
+    filters=None,
+):
+    """Create the AffinityVAE model.
+
+    Parameters
+    ----------
+    model_type : str
+        The type of model to create. Must be one of : a, b, u or gsd.
+    input_size : int
+        The size of the input.
+    channels : int
+        The number of channels in the model.
+    depth : int
+        The depth of the model.
+    lat_dims : int
+        The number of latent dimensions.
+    pose_dims : int
+        The number of pose dimensions.
+    bnorm_encoder : bool
+        Whether to use batch normalisation in the encoder.
+    bnorm_decoder : bool
+        Whether to use batch normalisation in the decoder.
+    n_splats : int
+        The number of splats in the Gaussian Splat Decoder.
+    gsd_conv_layers : int
+        The number of convolutional layers in the Gaussian Splat Decoder.
+    device : torch.device
+        The device to use for training and inference.
+    filters : list
+        The filters to use in the model.
+
+    """
+
+    if filters is not None:
+        filters = np.array(
+            np.array(filters).replace(" ", "").split(","), dtype=np.int64
+        )
+
+    if model_type == "a":
+        encoder = EncoderA(
+            input_size,
+            channels,
+            depth,
+            lat_dims,
+            pose_dims,
+            bnorm=bnorm_encoder,
+        )
+        decoder = DecoderA(
+            input_size,
+            channels,
+            depth,
+            lat_dims,
+            pose_dims,
+            bnorm=bnorm_decoder,
+        )
+    elif model_type == "b":
+        encoder = EncoderB(input_size, channels, depth, lat_dims, pose_dims)
+        decoder = DecoderB(input_size, channels, depth, lat_dims, pose_dims)
+    elif model_type == "u":
+        encoder = Encoder(
+            input_size=input_size,
+            capacity=channels,
+            filters=filters,
+            depth=depth,
+            latent_dims=lat_dims,
+            pose_dims=pose_dims,
+            bnorm=bnorm_encoder,
+        )
+        decoder = Decoder(
+            input_size=input_size,
+            capacity=channels,
+            filters=filters,
+            depth=depth,
+            latent_dims=lat_dims,
+            pose_dims=pose_dims,
+            bnorm=bnorm_decoder,
+        )
+    elif model_type == "gsd":
+        encoder = EncoderA(
+            input_size,
+            channels,
+            depth,
+            lat_dims,
+            pose_dims,
+            bnorm=bnorm_encoder,
+        )
+        decoder = GaussianSplatDecoder(
+            input_size,
+            n_splats=n_splats,
+            latent_dims=lat_dims,
+            output_channels=gsd_conv_layers,
+            device=device,
+            pose_dims=pose_dims,
+        )
+    else:
+        raise ValueError(
+            "Invalid model type",
+            model_type,
+            "must be one of : a, b, u or gsd",
+        )
+
+    vae = AffinityVAE(encoder, decoder)
+
+    return vae
 
 
 #

--- a/avae/models.py
+++ b/avae/models.py
@@ -140,7 +140,7 @@ def build_model(
         decoder = DecoderB(input_shape, channels, depth, lat_dims, pose_dims)
     elif model_type == "u":
         encoder = Encoder(
-            input_size=input_shape,
+            input_shape=input_shape,
             capacity=channels,
             filters=filters,
             depth=depth,

--- a/avae/train.py
+++ b/avae/train.py
@@ -17,7 +17,7 @@ from .data import load_data
 from .loss import AVAELoss
 from .models import build_model
 from .utils import accuracy, latest_file
-from .utils_learning import add_meta, pass_batch, set_device
+from .utils_learning import add_meta, configure_optimiser, pass_batch
 
 
 def train(
@@ -222,24 +222,10 @@ def train(
 
     logging.info(vae)
 
-    if opt_method == "adam":
-        optimizer = torch.optim.Adam(
-            params=vae.parameters(), lr=learning  # , weight_decay=1e-5
-        )
-    elif opt_method == "sgd":
-        optimizer = torch.optim.SGD(
-            params=vae.parameters(), lr=learning  # , weight_decay=1e-5
-        )
-    elif opt_method == "asgd":
-        optimizer = torch.optim.aSGD(
-            params=vae.parameters(), lr=learning  # , weight_decay=1e-5
-        )
-    else:
-        raise ValueError(
-            "Invalid optimisation method",
-            opt_method,
-            "must be adam or sgd if you have other methods in mind, this can be easily added to the train.py",
-        )
+    # ############################### OPTIMISER ###############################
+    optimizer = configure_optimiser(
+        opt_method=opt_method, model=vae, learning_rate=learning
+    )
 
     t_history = []
     v_history = []

--- a/avae/train.py
+++ b/avae/train.py
@@ -202,7 +202,7 @@ def train(
     # ############################### MODEL ###############################
     vae = build_model(
         model_type=model,
-        input_size=dshape,
+        input_shape=dshape,
         channels=channels,
         depth=depth,
         lat_dims=lat_dims,

--- a/avae/train.py
+++ b/avae/train.py
@@ -15,7 +15,7 @@ from . import settings, vis
 from .cyc_annealing import cyc_annealing
 from .data import load_data
 from .loss import AVAELoss
-from .models import AffinityVAE
+from .models import build_model
 from .utils import accuracy, latest_file
 from .utils_learning import add_meta, pass_batch, set_device
 
@@ -205,60 +205,20 @@ def train(
     pose = not (pose_dims == 0)
 
     # ############################### MODEL ###############################
-    if filters is not None:
-        filters = np.array(
-            np.array(filters).replace(" ", "").split(","), dtype=np.int64
-        )
-
-    if model == "a":
-        encoder = EncoderA(
-            dshape, channels, depth, lat_dims, pose_dims, bnorm=bnorm_encoder
-        )
-        decoder = DecoderA(
-            dshape, channels, depth, lat_dims, pose_dims, bnorm=bnorm_decoder
-        )
-    elif model == "b":
-        encoder = EncoderB(dshape, channels, depth, lat_dims, pose_dims)
-        decoder = DecoderB(dshape, channels, depth, lat_dims, pose_dims)
-    elif model == "u":
-        encoder = Encoder(
-            input_size=dshape,
-            capacity=channels,
-            filters=filters,
-            depth=depth,
-            latent_dims=lat_dims,
-            pose_dims=pose_dims,
-            bnorm=bnorm_encoder,
-        )
-        decoder = Decoder(
-            input_size=dshape,
-            capacity=channels,
-            filters=filters,
-            depth=depth,
-            latent_dims=lat_dims,
-            pose_dims=pose_dims,
-            bnorm=bnorm_decoder,
-        )
-    elif model == "gsd":
-        encoder = EncoderA(
-            dshape, channels, depth, lat_dims, pose_dims, bnorm=bnorm_encoder
-        )
-        decoder = GaussianSplatDecoder(
-            dshape,
-            n_splats=n_splats,
-            latent_dims=lat_dims,
-            output_channels=gsd_conv_layers,
-            device=device,
-            pose_dims=pose_dims,
-        )
-    else:
-        raise ValueError(
-            "Invalid model type",
-            model,
-            "must be one of : a, b, u or gsd",
-        )
-
-    vae = AffinityVAE(encoder, decoder)
+    vae = build_model(
+        model_type=model,
+        input_size=dshape,
+        channels=channels,
+        depth=depth,
+        lat_dims=lat_dims,
+        pose_dims=pose_dims,
+        bnorm_encoder=bnorm_encoder,
+        bnorm_decoder=bnorm_decoder,
+        n_splats=n_splats,
+        gsd_conv_layers=gsd_conv_layers,
+        device=device,
+        filters=filters,
+    )
 
     logging.info(vae)
 

--- a/avae/train.py
+++ b/avae/train.py
@@ -74,6 +74,10 @@ def train(
         Path to the data directory.
     datatype: str
         data file formats : mrc, npy
+    restart: bool
+        If True, the model will be restarted from the latest saved state.
+    state: str
+        Path to the model state file to be used for evaluation/restart.
     lim: int
         Limit the number of samples to load.
     splt: int
@@ -92,6 +96,8 @@ def train(
         Number of channels in the input data.
     depth: int
         Depth of the model.
+    filters: list
+        List of filters to use in the model.
     lat_dims: int
         Number of latent dimensions.
     pose_dims: int
@@ -139,13 +145,23 @@ def train(
         The method to use on the latent space classification. Can be neural network (NN), k nearest neighbourgs (KNN) or logistic regression (LR).
     bnorm_encoder: bool
         If True, batch normalisation is applied to the encoder.
-    bnrom_decoder: bool
+    bnorm_decoder: bool
         If True, batch normalisation is applied to the decoder.
     strategy: str
         The strategy to use for distributed training. Can be  'ddp', 'deepspeed' or 'fsdp".
     gsd_conv_layers: int
         activates convolution layers at the end of the differetiable decoder if set
-        and it is an integer defining the number of output channels  .
+        and it is an integer defining the number of output channels.
+    n_splats: int
+        The number of splats in the Gaussian Splat Decoder.
+    klred: str
+        The method to reduce the KL divergence. Can be 'mean' or 'sum'.
+    beta_load: str
+        Path to the beta values to load.
+    gamma_load: str
+        Path to the gamma values to load.
+    rescale: bool
+        If True, the input data is rescaled to have a mean of 0 and std of 1.
     """
     lt.pytorch.seed_everything(42)
 

--- a/avae/utils_learning.py
+++ b/avae/utils_learning.py
@@ -227,3 +227,45 @@ def add_meta(
         [meta_df, meta], ignore_index=False
     )  # ignore index doesn't overwrite
     return meta_df
+
+
+def configure_optimiser(
+    opt_method: str, model: torch.nn.Module, learning_rate: float
+):
+    """
+    Configure the optimiser for the training.
+
+    Parameters
+    ----------
+    opt_method : str
+        Optimisation method.
+    model : torch.nn.Module
+        Model to be trained.
+    learning_rate : float
+        Learning rate for the optimiser.
+
+    Returns
+    -------
+    optimizer : torch.optim
+        Optimiser for the training.
+    """
+    if opt_method == "adam":
+        optimizer = torch.optim.Adam(
+            params=model.parameters(), lr=learning_rate  # , weight_decay=1e-5
+        )
+    elif opt_method == "sgd":
+        optimizer = torch.optim.SGD(
+            params=model.parameters(), lr=learning_rate  # , weight_decay=1e-5
+        )
+    elif opt_method == "asgd":
+        optimizer = torch.optim.aSGD(
+            params=model.parameters(), lr=learning_rate  # , weight_decay=1e-5
+        )
+    else:
+        raise ValueError(
+            "Invalid optimisation method",
+            opt_method,
+            "must be adam or sgd if you have other methods in mind, this can be easily added to the train.py",
+        )
+
+    return optimizer

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -46,7 +46,7 @@ class LossTest(unittest.TestCase):
         self.decoder_3d = Decoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64, 64),
+            input_shape=(64, 64, 64),
             latent_dims=16,
             pose_dims=3,
         )

--- a/tests/test_loss.py
+++ b/tests/test_loss.py
@@ -37,7 +37,7 @@ class LossTest(unittest.TestCase):
         self.encoder_3d = Encoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64, 64),
+            input_shape=(64, 64, 64),
             latent_dims=16,
             pose_dims=3,
             bnorm=True,

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,7 +23,7 @@ class ModelInstanceTest(unittest.TestCase):
         self.decoder_3d = Decoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64, 64),
+            input_shape=(64, 64, 64),
             latent_dims=16,
             pose_dims=3,
         )
@@ -40,7 +40,7 @@ class ModelInstanceTest(unittest.TestCase):
         self.decoder_2d = Decoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64),
+            input_shape=(64, 64),
             latent_dims=16,
             pose_dims=3,
         )
@@ -124,7 +124,7 @@ class ModelParamsTest(unittest.TestCase):
         )
         with pytest.raises(RuntimeError) as errinfo:
             Decoder(
-                input_size=self.input_size,
+                input_shape=self.input_size,
             )
         assert (
             str(errinfo.value)
@@ -146,7 +146,7 @@ class ModelParamsTest(unittest.TestCase):
         with pytest.raises(RuntimeError) as errinfo:
             Decoder(
                 filters=[0, -1],
-                input_size=self.input_size,
+                input_shape=self.input_size,
             )
         assert (
             str(errinfo.value)
@@ -166,7 +166,7 @@ class ModelParamsTest(unittest.TestCase):
         with pytest.raises(AssertionError) as errinfo:
             Decoder(
                 filters=[2, 4, 16, 32],
-                input_size=(8, 8),
+                input_shape=(8, 8),
             )
         assert (
             str(errinfo.value)
@@ -188,7 +188,7 @@ class ModelParamsTest(unittest.TestCase):
             Decoder(
                 capacity=8,
                 depth=4,
-                input_size=(8, 8),
+                input_shape=(8, 8),
             )
         assert (
             str(errinfo.value)
@@ -210,7 +210,7 @@ class ModelParamsTest(unittest.TestCase):
             Decoder(
                 capacity=8,
                 depth=-1,
-                input_size=self.input_size,
+                input_shape=self.input_size,
             )
         assert (
             str(errinfo.value)
@@ -234,7 +234,7 @@ class ModelParamsTest(unittest.TestCase):
                 capacity=8,
                 depth=4,
                 latent_dims=-1,
-                input_size=self.input_size,
+                input_shape=self.input_size,
             )
         assert (
             str(errinfo.value)
@@ -255,7 +255,7 @@ class ModelParamsTest(unittest.TestCase):
             dec = Decoder(
                 capacity=dim,
                 depth=1,
-                input_size=self.input_size,
+                input_shape=self.input_size,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -272,7 +272,7 @@ class ModelParamsTest(unittest.TestCase):
             depth=0,
         )
         dec = Decoder(
-            input_size=(128,),
+            input_shape=(128,),
             depth=0,
         )
         model = avae(enc, dec)
@@ -291,7 +291,7 @@ class ModelParamsTest(unittest.TestCase):
             dec = Decoder(
                 capacity=8,
                 depth=dim,
-                input_size=self.input_size,
+                input_shape=self.input_size,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -311,7 +311,7 @@ class ModelParamsTest(unittest.TestCase):
             )
             dec = Decoder(
                 filters=dim,
-                input_size=self.input_size,
+                input_shape=self.input_size,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -328,7 +328,7 @@ class ModelParamsTest(unittest.TestCase):
         )
         dec = Decoder(
             filters=[16],
-            input_size=self.input_size,
+            input_shape=self.input_size,
             latent_dims=16,
             pose_dims=3,
         )
@@ -348,7 +348,7 @@ class ModelParamsTest(unittest.TestCase):
             )
             dec = Decoder(
                 filters=[8, 16],
-                input_size=self.input_size,
+                input_shape=self.input_size,
                 latent_dims=dim,
                 pose_dims=3,
             )
@@ -374,7 +374,9 @@ class ModelParamsTest(unittest.TestCase):
     def test_batchnorm(self):
 
         enc = Encoder(filters=[8, 16], input_size=self.input_size, bnorm=True)
-        dec = Decoder(filters=[8, 16], input_size=self.input_size, bnorm=False)
+        dec = Decoder(
+            filters=[8, 16], input_shape=self.input_size, bnorm=False
+        )
         model = avae(enc, dec)
         output = model(self.input)
         self.assertEqual(output[0].shape, self.input.shape)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,7 +14,7 @@ class ModelInstanceTest(unittest.TestCase):
         self.encoder_3d = Encoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64, 64),
+            input_shape=(64, 64, 64),
             latent_dims=16,
             pose_dims=3,
             bnorm=True,
@@ -33,7 +33,7 @@ class ModelInstanceTest(unittest.TestCase):
         self.encoder_2d = Encoder(
             capacity=8,
             depth=4,
-            input_size=(64, 64),
+            input_shape=(64, 64),
             latent_dims=16,
             pose_dims=3,
         )
@@ -89,7 +89,7 @@ class ModelInstanceTest(unittest.TestCase):
 
 class ModelParamsTest(unittest.TestCase):
     def setUp(self):
-        self.input_size = (64, 64)
+        self.input_shape = (64, 64)
         self.input = randn(14, 1, 64, 64)
         self.capacity_params = [9, 64]
         self.depth_params = [2, 4]
@@ -104,19 +104,19 @@ class ModelParamsTest(unittest.TestCase):
             Encoder()
         assert (
             str(errinfo.value)
-            == "Encoder.__init__() missing 1 required positional argument: 'input_size'"
+            == "Encoder.__init__() missing 1 required positional argument: 'input_shape'"
         )
         with pytest.raises(TypeError) as errinfo:
             Decoder()
         assert (
             str(errinfo.value)
-            == "Decoder.__init__() missing 1 required positional argument: 'input_size'"
+            == "Decoder.__init__() missing 1 required positional argument: 'input_shape'"
         )
 
         # no capacity no filters scenario
         with pytest.raises(RuntimeError) as errinfo:
             Encoder(
-                input_size=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -124,7 +124,7 @@ class ModelParamsTest(unittest.TestCase):
         )
         with pytest.raises(RuntimeError) as errinfo:
             Decoder(
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -137,7 +137,7 @@ class ModelParamsTest(unittest.TestCase):
         with pytest.raises(RuntimeError) as errinfo:
             Encoder(
                 filters=[0, -1],
-                input_size=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -146,7 +146,7 @@ class ModelParamsTest(unittest.TestCase):
         with pytest.raises(RuntimeError) as errinfo:
             Decoder(
                 filters=[0, -1],
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -157,7 +157,7 @@ class ModelParamsTest(unittest.TestCase):
         with pytest.raises(AssertionError) as errinfo:
             Encoder(
                 filters=[2, 4, 16, 32],
-                input_size=(8, 8),
+                input_shape=(8, 8),
             )
         assert (
             str(errinfo.value)
@@ -178,7 +178,7 @@ class ModelParamsTest(unittest.TestCase):
             Encoder(
                 capacity=8,
                 depth=4,
-                input_size=(8, 8),
+                input_shape=(8, 8),
             )
         assert (
             str(errinfo.value)
@@ -200,7 +200,7 @@ class ModelParamsTest(unittest.TestCase):
             Encoder(
                 capacity=8,
                 depth=-1,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -210,7 +210,7 @@ class ModelParamsTest(unittest.TestCase):
             Decoder(
                 capacity=8,
                 depth=-1,
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -223,7 +223,7 @@ class ModelParamsTest(unittest.TestCase):
                 capacity=8,
                 depth=4,
                 latent_dims=0,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -234,7 +234,7 @@ class ModelParamsTest(unittest.TestCase):
                 capacity=8,
                 depth=4,
                 latent_dims=-1,
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
             )
         assert (
             str(errinfo.value)
@@ -248,14 +248,14 @@ class ModelParamsTest(unittest.TestCase):
             enc = Encoder(
                 capacity=dim,
                 depth=1,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
             dec = Decoder(
                 capacity=dim,
                 depth=1,
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -268,7 +268,7 @@ class ModelParamsTest(unittest.TestCase):
         # no conv
         input = randn(14, 1, 128)
         enc = Encoder(
-            input_size=(128,),
+            input_shape=(128,),
             depth=0,
         )
         dec = Decoder(
@@ -284,14 +284,14 @@ class ModelParamsTest(unittest.TestCase):
             enc = Encoder(
                 capacity=8,
                 depth=dim,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
             dec = Decoder(
                 capacity=8,
                 depth=dim,
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -305,13 +305,13 @@ class ModelParamsTest(unittest.TestCase):
 
             enc = Encoder(
                 filters=dim,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
             dec = Decoder(
                 filters=dim,
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=3,
             )
@@ -322,13 +322,13 @@ class ModelParamsTest(unittest.TestCase):
         # uneven filters
         enc = Encoder(
             filters=dim,
-            input_size=self.input_size,
+            input_shape=self.input_shape,
             latent_dims=16,
             pose_dims=3,
         )
         dec = Decoder(
             filters=[16],
-            input_shape=self.input_size,
+            input_shape=self.input_shape,
             latent_dims=16,
             pose_dims=3,
         )
@@ -342,13 +342,13 @@ class ModelParamsTest(unittest.TestCase):
 
             enc = Encoder(
                 filters=[8, 16],
-                input_size=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=dim,
                 pose_dims=3,
             )
             dec = Decoder(
                 filters=[8, 16],
-                input_shape=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=dim,
                 pose_dims=3,
             )
@@ -363,7 +363,7 @@ class ModelParamsTest(unittest.TestCase):
             enc = Encoder(
                 capacity=8,
                 depth=4,
-                input_size=self.input_size,
+                input_shape=self.input_shape,
                 latent_dims=16,
                 pose_dims=dim,
                 bnorm=True,
@@ -373,9 +373,11 @@ class ModelParamsTest(unittest.TestCase):
 
     def test_batchnorm(self):
 
-        enc = Encoder(filters=[8, 16], input_size=self.input_size, bnorm=True)
+        enc = Encoder(
+            filters=[8, 16], input_shape=self.input_shape, bnorm=True
+        )
         dec = Decoder(
-            filters=[8, 16], input_shape=self.input_size, bnorm=False
+            filters=[8, 16], input_shape=self.input_shape, bnorm=False
         )
         model = avae(enc, dec)
         output = model(self.input)


### PR DESCRIPTION
As described in #296, simplifying the training script to make it clear what is happening. 

- Moved model and optimiser configuration to its own files.
- Created function for gamma/beta annealing configuration, and moved it to its own file.
- Moved `pass_batch` functionally back to train.py and evaluation.py as it can be a bit confusing to see what is happening if is not explicit in the batch loop.
- Aesthetic changes to make `train.py` script shorter.
- Renamed variables for further clarity (e.g `input_size` to `input_shape`).
- Added missing doctrings.
- Updated readme with the latest configuration option and some aesthetic changes for readability (a lot more changes are needed to the README).  